### PR TITLE
Allow Client HTTP Engine Registration

### DIFF
--- a/rest-client-base/src/main/java/org/jboss/resteasy/microprofile/client/RestClientBuilderImpl.java
+++ b/rest-client-base/src/main/java/org/jboss/resteasy/microprofile/client/RestClientBuilderImpl.java
@@ -338,11 +338,15 @@ public class RestClientBuilderImpl implements RestClientBuilder {
         if (httpEngine != null) {
             resteasyClientBuilder.httpEngine(httpEngine);
         } else {
-            Object propEngine = getConfiguration().getProperty("org.jboss.resteasy.http.client.engine");
-
-            if (propEngine instanceof ClientHttpEngine) {
-                resteasyClientBuilder.httpEngine((ClientHttpEngine) propEngine);
-            } else if (useURLConnection()) {
+            boolean registerEngine = false;
+            for (Object p : getBuilderDelegate().getProviderFactory().getProviderInstances()) {
+                if (p instanceof ClientHttpEngine) {
+                    resteasyClientBuilder.httpEngine((ClientHttpEngine) p);
+                    registerEngine = true;
+                    break;
+                }
+            }
+            if (!registerEngine && useURLConnection()) {
                 resteasyClientBuilder
                         .httpEngine(new URLConnectionClientEngineBuilder().resteasyClientBuilder(resteasyClientBuilder)
                                 .build());

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/microprofile/test/client/integration/RestClientProxyTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/microprofile/test/client/integration/RestClientProxyTest.java
@@ -92,7 +92,7 @@ public class RestClientProxyTest {
     }
 
     @Test
-    public void testHTTP2() {
+    public void testHTTP2ByRegistration() {
         RestClientBuilder builder = RestClientBuilder.newBuilder().baseUri(URI.create("https://nghttp2.org/"));
 
         Vertx vertx = Vertx.vertx();
@@ -102,7 +102,7 @@ public class RestClientProxyTest {
         options.setProtocolVersion(HttpVersion.HTTP_2);
         options.setUseAlpn(true);
 
-        builder.property("org.jboss.resteasy.http.client.engine", new VertxClientHttpEngine(vertx, options));
+        builder.register(new VertxClientHttpEngine(vertx, options));
 
         NgHTTP2 client = builder.build(NgHTTP2.class);
 


### PR DESCRIPTION
This replaces #20. This is just squashed to a single commit and rebased.