### PR TITLE
Attempt to use CDI InterceptionFactory

### DIFF
--- a/rest-client-base/src/main/java/org/jboss/resteasy/microprofile/client/ProxyInvocationHandler.java
+++ b/rest-client-base/src/main/java/org/jboss/resteasy/microprofile/client/ProxyInvocationHandler.java
@@ -23,24 +23,12 @@ import java.lang.annotation.Annotation;
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-import java.lang.reflect.Modifier;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.stream.Collectors;
 
-import jakarta.enterprise.context.spi.CreationalContext;
-import jakarta.enterprise.inject.spi.BeanManager;
-import jakarta.enterprise.inject.spi.CDI;
-import jakarta.enterprise.inject.spi.InterceptionType;
-import jakarta.enterprise.inject.spi.Interceptor;
 import jakarta.ws.rs.ProcessingException;
 import jakarta.ws.rs.client.ResponseProcessingException;
 import jakarta.ws.rs.ext.ParamConverter;
@@ -59,29 +47,18 @@ public class ProxyInvocationHandler implements InvocationHandler {
 
     private final Set<Object> providerInstances;
 
-    private final Map<Method, List<InvocationContextImpl.InterceptorInvocation>> interceptorChains;
-
     private final ResteasyClient client;
-
-    private final CreationalContext<?> creationalContext;
 
     private final AtomicBoolean closed;
 
     public ProxyInvocationHandler(final Class<?> restClientInterface,
             final Object target,
             final Set<Object> providerInstances,
-            final ResteasyClient client, final BeanManager beanManager) {
+            final ResteasyClient client) {
         this.target = target;
         this.providerInstances = providerInstances;
         this.client = client;
         this.closed = new AtomicBoolean();
-        if (beanManager != null) {
-            this.creationalContext = beanManager.createCreationalContext(null);
-            this.interceptorChains = initInterceptorChains(beanManager, creationalContext, restClientInterface);
-        } else {
-            this.creationalContext = null;
-            this.interceptorChains = Collections.emptyMap();
-        }
     }
 
     @Override
@@ -159,40 +136,34 @@ public class ProxyInvocationHandler implements InvocationHandler {
             args = argsReplacement;
         }
 
-        List<InvocationContextImpl.InterceptorInvocation> chain = interceptorChains.get(method);
-        if (chain != null) {
-            // Invoke business method interceptors
-            return new InvocationContextImpl(target, method, args, chain).proceed();
-        } else {
-            try {
-                return method.invoke(target, args);
-            } catch (InvocationTargetException e) {
-                Throwable cause = e.getCause();
-                if (cause instanceof CompletionException) {
-                    cause = cause.getCause();
-                }
-                if (cause instanceof ExceptionMapping.HandlerException) {
-                    ((ExceptionMapping.HandlerException) cause).mapException(method);
-                    // no applicable exception mapper found or applicable mapper returned null
-                    return null;
-                }
-                if (cause instanceof ResponseProcessingException) {
-                    ResponseProcessingException rpe = (ResponseProcessingException) cause;
-                    cause = rpe.getCause();
-                    if (cause instanceof RuntimeException) {
-                        throw cause;
-                    }
-                } else {
-                    if (cause instanceof ProcessingException &&
-                            cause.getCause() instanceof ClientHeaderFillingException) {
-                        throw cause.getCause().getCause();
-                    }
-                    if (cause instanceof RuntimeException) {
-                        throw cause;
-                    }
-                }
-                throw e;
+        try {
+            return method.invoke(target, args);
+        } catch (InvocationTargetException e) {
+            Throwable cause = e.getCause();
+            if (cause instanceof CompletionException) {
+                cause = cause.getCause();
             }
+            if (cause instanceof ExceptionMapping.HandlerException) {
+                ((ExceptionMapping.HandlerException) cause).mapException(method);
+                // no applicable exception mapper found or applicable mapper returned null
+                return null;
+            }
+            if (cause instanceof ResponseProcessingException) {
+                ResponseProcessingException rpe = (ResponseProcessingException) cause;
+                cause = rpe.getCause();
+                if (cause instanceof RuntimeException) {
+                    throw cause;
+                }
+            } else {
+                if (cause instanceof ProcessingException &&
+                        cause.getCause() instanceof ClientHeaderFillingException) {
+                    throw cause.getCause().getCause();
+                }
+                if (cause instanceof RuntimeException) {
+                    throw cause;
+                }
+            }
+            throw e;
         }
     }
 
@@ -210,9 +181,6 @@ public class ProxyInvocationHandler implements InvocationHandler {
 
     private void close() {
         if (closed.compareAndSet(false, true)) {
-            if (creationalContext != null) {
-                creationalContext.release();
-            }
             client.close();
         }
     }
@@ -227,77 +195,4 @@ public class ProxyInvocationHandler implements InvocationHandler {
         }
         return genericTypes;
     }
-
-    private static List<Annotation> getBindings(Annotation[] annotations, BeanManager beanManager) {
-        if (annotations.length == 0) {
-            return Collections.emptyList();
-        }
-        List<Annotation> bindings = new ArrayList<>();
-        for (Annotation annotation : annotations) {
-            if (beanManager.isInterceptorBinding(annotation.annotationType())) {
-                bindings.add(annotation);
-            }
-        }
-        return bindings;
-    }
-
-    private static BeanManager getBeanManager(Class<?> restClientInterface) {
-        try {
-            CDI<Object> current = CDI.current();
-            return current != null ? current.getBeanManager() : null;
-        } catch (IllegalStateException e) {
-            LOGGER.warnf("CDI container is not available - interceptor bindings declared on %s will be ignored",
-                    restClientInterface.getSimpleName());
-            return null;
-        }
-    }
-
-    private static Map<Method, List<InvocationContextImpl.InterceptorInvocation>> initInterceptorChains(
-            BeanManager beanManager, CreationalContext<?> creationalContext, Class<?> restClientInterface) {
-
-        Map<Method, List<InvocationContextImpl.InterceptorInvocation>> chains = new HashMap<>();
-        // Interceptor as a key in a map is not entirely correct (custom interceptors) but should work in most cases
-        Map<Interceptor<?>, Object> interceptorInstances = new HashMap<>();
-
-        List<Annotation> classLevelBindings = getBindings(restClientInterface.getAnnotations(), beanManager);
-
-        for (Method method : restClientInterface.getMethods()) {
-            if (method.isDefault() || Modifier.isStatic(method.getModifiers())) {
-                continue;
-            }
-            List<Annotation> methodLevelBindings = getBindings(method.getAnnotations(), beanManager);
-
-            if (!classLevelBindings.isEmpty() || !methodLevelBindings.isEmpty()) {
-
-                Annotation[] interceptorBindings = merge(methodLevelBindings, classLevelBindings);
-
-                List<Interceptor<?>> interceptors = beanManager.resolveInterceptors(InterceptionType.AROUND_INVOKE,
-                        interceptorBindings);
-                if (!interceptors.isEmpty()) {
-                    List<InvocationContextImpl.InterceptorInvocation> chain = new ArrayList<>();
-                    for (Interceptor<?> interceptor : interceptors) {
-                        chain.add(new InvocationContextImpl.InterceptorInvocation(interceptor,
-                                interceptorInstances.computeIfAbsent(interceptor,
-                                        i -> beanManager.getReference(i, i.getBeanClass(), creationalContext))));
-                    }
-                    chains.put(method, chain);
-                }
-            }
-        }
-        return chains.isEmpty() ? Collections.emptyMap() : chains;
-    }
-
-    private static Annotation[] merge(List<Annotation> methodLevelBindings, List<Annotation> classLevelBindings) {
-        Set<Class<? extends Annotation>> types = methodLevelBindings.stream()
-                .map(a -> a.annotationType())
-                .collect(Collectors.toSet());
-        List<Annotation> merged = new ArrayList<>(methodLevelBindings);
-        for (Annotation annotation : classLevelBindings) {
-            if (!types.contains(annotation.annotationType())) {
-                merged.add(annotation);
-            }
-        }
-        return merged.toArray(new Annotation[] {});
-    }
-
 }

--- a/rest-client-base/src/main/java/org/jboss/resteasy/microprofile/client/RestClientBuilderImpl.java
+++ b/rest-client-base/src/main/java/org/jboss/resteasy/microprofile/client/RestClientBuilderImpl.java
@@ -385,7 +385,7 @@ public class RestClientBuilderImpl implements RestClientBuilder {
         interfaces[2] = Closeable.class;
 
         T proxy = (T) Proxy.newProxyInstance(classLoader, interfaces,
-                new ProxyInvocationHandler(aClass, actualClient, getLocalProviderInstances(), client, beanManager));
+                new ProxyInvocationHandler(aClass, actualClient, getLocalProviderInstances(), client));
         ClientHeaderProviders.registerForClass(aClass, proxy, beanManager);
         return proxy;
     }

--- a/rest-client-base/src/main/java/org/jboss/resteasy/microprofile/client/RestClientExtension.java
+++ b/rest-client-base/src/main/java/org/jboss/resteasy/microprofile/client/RestClientExtension.java
@@ -53,7 +53,7 @@ public class RestClientExtension implements Extension {
             Optional<String> maybeConfigKey = extractConfigKey(annotation);
 
             proxyTypes.add(new RestClientData(javaClass, maybeUri, maybeConfigKey));
-            type.veto();
+            // no need to veto() these types because interfaces cannot become beans anyway
         } else {
             errors.add(new IllegalArgumentException("Rest client needs to be an interface " + javaClass));
         }
@@ -107,12 +107,12 @@ public class RestClientExtension implements Extension {
         // nothing to do
     }
 
-    private static class RestClientData {
-        private final Class<?> javaClass;
+    private static class RestClientData<T> {
+        private final Class<T> javaClass;
         private final Optional<String> baseUri;
         private final Optional<String> configKey;
 
-        private RestClientData(final Class<?> javaClass, final Optional<String> baseUri,
+        private RestClientData(final Class<T> javaClass, final Optional<String> baseUri,
                 final Optional<String> configKey) {
             this.javaClass = javaClass;
             this.baseUri = baseUri;

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/microprofile/test/client/integration/ContainerRestClientProxyTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/microprofile/test/client/integration/ContainerRestClientProxyTest.java
@@ -64,11 +64,13 @@ public class ContainerRestClientProxyTest {
                         InterceptedClient.class,
                         TestResource.class,
                         ClientInterceptor.class,
-                        ClientInterceptorBinding.class)
+                        ClientInterceptorBinding.class,
+                        ClientMethodInterceptor.class,
+                        ClientMethodInterceptorBinding.class)
                 .addAsManifestResource(PermissionUtil.createPermissionsXmlAsset(
-                                new PropertyPermission("arquillian.*", "read"),
-                                new ReflectPermission("suppressAccessChecks"),
-                                new RuntimePermission("accessDeclaredMembers")),
+                        new PropertyPermission("arquillian.*", "read"),
+                        new ReflectPermission("suppressAccessChecks"),
+                        new RuntimePermission("accessDeclaredMembers")),
                         "permissions.xml")
                 .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
     }
@@ -80,7 +82,11 @@ public class ContainerRestClientProxyTest {
     @Test
     public void intercepted() {
         Assert.assertNotNull(client);
+        Assert.assertFalse(ClientInterceptor.invoked);
+        Assert.assertFalse(ClientMethodInterceptor.invoked);
         Assert.assertEquals("test", client.get());
+        Assert.assertTrue(ClientInterceptor.invoked);
+        Assert.assertTrue(ClientMethodInterceptor.invoked);
     }
 
     @RegisterRestClient
@@ -91,6 +97,7 @@ public class ContainerRestClientProxyTest {
 
         @GET
         @Path("/test")
+        @ClientMethodInterceptorBinding
         String get();
 
     }
@@ -109,12 +116,33 @@ public class ContainerRestClientProxyTest {
     @Interceptor
     public static class ClientInterceptor {
 
+        public static boolean invoked = false;
+
         @Inject
         @Intercepted
         Bean<?> bean;
 
         @AroundInvoke
         public Object doSomething(InvocationContext ic) throws Exception {
+            invoked = true;
+            return ic.proceed();
+        }
+    }
+
+    @Priority(1)
+    @Interceptor
+    @ClientMethodInterceptorBinding
+    public static class ClientMethodInterceptor {
+
+        public static boolean invoked = false;
+
+        @Inject
+        @Intercepted
+        Bean<?> bean;
+
+        @AroundInvoke
+        public Object doSomething(InvocationContext ic) throws Exception {
+            invoked = true;
             return ic.proceed();
         }
     }
@@ -123,5 +151,11 @@ public class ContainerRestClientProxyTest {
     @Retention(RetentionPolicy.RUNTIME)
     @Target({ ElementType.TYPE, ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER })
     public @interface ClientInterceptorBinding {
+    }
+
+    @InterceptorBinding
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target({ ElementType.TYPE, ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER })
+    public @interface ClientMethodInterceptorBinding {
     }
 }

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/microprofile/test/client/integration/ContainerRestClientProxyTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/microprofile/test/client/integration/ContainerRestClientProxyTest.java
@@ -1,0 +1,127 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2023 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.resteasy.microprofile.test.client.integration;
+
+import java.io.IOException;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.lang.reflect.ReflectPermission;
+import java.util.PropertyPermission;
+
+import jakarta.annotation.Priority;
+import jakarta.enterprise.context.RequestScoped;
+import jakarta.enterprise.inject.Intercepted;
+import jakarta.enterprise.inject.spi.Bean;
+import jakarta.inject.Inject;
+import jakarta.interceptor.AroundInvoke;
+import jakarta.interceptor.Interceptor;
+import jakarta.interceptor.InterceptorBinding;
+import jakarta.interceptor.InvocationContext;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+import org.eclipse.microprofile.rest.client.inject.RestClient;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.resteasy.microprofile.test.util.TestEnvironment;
+import org.jboss.resteasy.utils.PermissionUtil;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+@RunWith(Arquillian.class)
+public class ContainerRestClientProxyTest {
+
+    @Deployment
+    public static WebArchive deployment() throws IOException {
+        return TestEnvironment.createWarWithConfigUrl(ContainerRestClientProxyTest.class, InterceptedClient.class, "test-app")
+                .addClasses(
+                        InterceptedClient.class,
+                        TestResource.class,
+                        ClientInterceptor.class,
+                        ClientInterceptorBinding.class)
+                .addAsManifestResource(PermissionUtil.createPermissionsXmlAsset(
+                                new PropertyPermission("arquillian.*", "read"),
+                                new ReflectPermission("suppressAccessChecks"),
+                                new RuntimePermission("accessDeclaredMembers")),
+                        "permissions.xml")
+                .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
+    }
+
+    @Inject
+    @RestClient
+    private InterceptedClient client;
+
+    @Test
+    public void intercepted() {
+        Assert.assertNotNull(client);
+        Assert.assertEquals("test", client.get());
+    }
+
+    @RegisterRestClient
+    @RequestScoped
+    @ClientInterceptorBinding
+    @Path("/test")
+    public interface InterceptedClient {
+
+        @GET
+        @Path("/test")
+        String get();
+
+    }
+
+    @Path("/test")
+    public static class TestResource {
+        @GET
+        @Path("/test")
+        public String get() {
+            return "test";
+        }
+    }
+
+    @ClientInterceptorBinding
+    @Priority(1)
+    @Interceptor
+    public static class ClientInterceptor {
+
+        @Inject
+        @Intercepted
+        Bean<?> bean;
+
+        @AroundInvoke
+        public Object doSomething(InvocationContext ic) throws Exception {
+            return ic.proceed();
+        }
+    }
+
+    @InterceptorBinding
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target({ ElementType.TYPE, ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER })
+    public @interface ClientInterceptorBinding {
+    }
+}

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/microprofile/test/util/TestEnvironment.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/microprofile/test/util/TestEnvironment.java
@@ -60,7 +60,7 @@ public class TestEnvironment {
         final String url = getHttpUrl() + test.getSimpleName()
                 + (path == null ? "" : (path.charAt(0) == '/' ? path : "/" + path));
         return addConfigProperties(createWar(test),
-                Collections.singletonMap(resource.getCanonicalName() + "/mp-rest/url", url));
+                Collections.singletonMap(resource.getName() + "/mp-rest/url", url));
     }
 
     public static WebArchive createWarWithConfigUrl(final String deploymentName, final Class<?> resource,


### PR DESCRIPTION
This PR attempts to remove the need to handle interception chains for `@RegisterRestClient` proxies manually.
Instead it registers the proxies as CDI beans and uses `InterceptionFactory` to let CDI fully handle interception.

I've ran the tests with `mvn clean verify -Dversion.org.wildfly=29.0.0.Beta1-SNAPSHOT` using WFLY with latest Weld (5.1.1.Final) in it.
There are also some notes in the code regarding what could be improved but if it worked this way up until now, it should be the same with these changes.

@jamezp please review carefully as this seems to have poor test coverage overall and it might be that I missed some RE parts that I am blind to :)

Replaces #181