### PR TITLE
Add Weld module dependencies. This was previously not required becuas…

### DIFF
--- a/galleon-pack/common/src/main/resources/modules/system/layers/base/org/jboss/resteasy/resteasy-client-microprofile/main/module.xml
+++ b/galleon-pack/common/src/main/resources/modules/system/layers/base/org/jboss/resteasy/resteasy-client-microprofile/main/module.xml
@@ -41,6 +41,8 @@
         <module name="org.jboss.resteasy.resteasy-client" services="import" />
         <module name="org.jboss.resteasy.resteasy-core" services="import" />
         <module name="org.jboss.resteasy.resteasy-core-spi" />
+        <module name="org.jboss.weld.core" />
+        <module name="org.jboss.weld.spi" />
         <module name="org.reactivestreams" />
     </dependencies>
 </module>


### PR DESCRIPTION
…e of the use of the org.jboss.resteasy.resteasy-cdi module. However, that was removed.