### PR TITLE
WIP: Instantiate a new proxy instance for subresources (github issue #239)

### DIFF
--- a/rest-client-base/src/main/java/org/jboss/resteasy/microprofile/client/RestClientBuilderImpl.java
+++ b/rest-client-base/src/main/java/org/jboss/resteasy/microprofile/client/RestClientBuilderImpl.java
@@ -384,7 +384,7 @@ public class RestClientBuilderImpl implements RestClientBuilder {
         interfaces[2] = Closeable.class;
 
         T proxy = (T) Proxy.newProxyInstance(classLoader, interfaces,
-                new ProxyInvocationHandler(aClass, actualClient, getLocalProviderInstances(), client));
+                new ProxyInvocationHandler(aClass, actualClient, getLocalProviderInstances(), client, classLoader));
         ClientHeaderProviders.registerForClass(aClass, proxy, beanManager);
         return proxy;
     }


### PR DESCRIPTION
This fixes issue https://github.com/resteasy/resteasy-microprofile/issues/239

I would like to request feedback on the approach used.

In order to apply the jax-rs providers registered with the restclient builder, as well as to wrap the subresource method calls in the ProxyInvocationHandler to handle exceptions, i have to detect calls from the parent resource that return a subresource. 

I made the assumption here that all methods on the parent resource that would be invoked on this proxy would be annotated with an `@HttpMethod` annotation (`@GET`, `@PUT` etc); except for `close` and those methods returnin a subresource controller.

With the current implementation, in order to create a new proxy for this subresource, i needed an instance of the rest client builder that was used to instantiate the parent resource. This looks like an antipattern - the builder instance will have to live as long as the proxy instance.

Another option that I plan to implement is to recursively scan for subresources methods before building the proxy, and instantiate proxies starting from the leaves of the tree; providing them with a `Map<Method, "Proxy instances">` of methods that should just return a subresource proxy instance. That way all proxies would be instantiated during the `build` call.

I also suggested the addition of a test in the microprofile tck: see https://github.com/eclipse/microprofile-rest-client/pull/367