### PR TITLE
Upgrade RESTEasy from 6.2.6.Final to 6.2.7.Final.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
 
         <version.org.jboss.logging.jboss-logging>3.5.3.Final</version.org.jboss.logging.jboss-logging>
         <version.org.jboss.logging.jboss-logging-tools>2.2.1.Final</version.org.jboss.logging.jboss-logging-tools>
-        <version.org.jboss.resteasy>6.2.6.Final</version.org.jboss.resteasy>
+        <version.org.jboss.resteasy>6.2.7.Final</version.org.jboss.resteasy>
 
         <version.org.wildfly>30.0.1.Final</version.org.wildfly>
         <!-- TODO (jrp) this can be removed when RESTEASY-2973 is resolved -->


### PR DESCRIPTION
Tag: https://github.com/resteasy/resteasy/releases/tag/6.2.7.Final