### PR TITLE
[issue-253] migrated from junit4 to junit5

### DIFF
--- a/.github/workflows/wildfly-build.yml
+++ b/.github/workflows/wildfly-build.yml
@@ -9,6 +9,10 @@ on:
   schedule:
     - cron: '0 0 * * *' # Every day at 00:00 UTC
 
+env:
+  GALLEON_VERSION: 7.0.0.Beta5
+  WILDFLY_MP_VERSION: 5.0.0.Beta3
+
 # Only run the latest job and cancel previous ones
 concurrency:
   group: 'wildfly-${{ github.ref || github.run_id }}'
@@ -46,7 +50,7 @@ jobs:
           distribution: 'temurin'
           cache: 'maven'
       - name: Build with Maven Java ${{ matrix.java }}
-        run: mvn  -B clean install '-Dversion.org.wildfly=${{ needs.wildfly-build.outputs.wildfly-version }}'
+        run: mvn  -B clean install '-Dversion.org.wildfly=${{ needs.wildfly-build.outputs.wildfly-version }}' '-Dversion.org.wildfly.galleon-plugins=${{ env.GALLEON_VERSION}}' '-Dversion.org.wildfly.plugins.wildfly-maven-plugin=${{ env.WILDFLY_MP_VERSION}}'
       - name: Upload surefire reports
         uses: actions/upload-artifact@v4
         if: failure()
@@ -84,7 +88,7 @@ jobs:
           cache: 'maven'
       - name: Build with Maven Java ${{ matrix.java }} on WildFly ${{ matrix.wildfly-version }} - ${{ matrix.os }}
         run:  |
-          mvn clean install -U -B -fae '-Dserver.version=${{ matrix.wildfly-version }}' '-Dgithub.actions'
+          mvn clean install -U -B -fae '-Dserver.version=${{ matrix.wildfly-version }}' '-Dgithub.actions' '-Dversion.org.wildfly.galleon-plugins=${{ env.GALLEON_VERSION}}' '-Dversion.org.wildfly.plugins.wildfly-maven-plugin=${{ env.WILDFLY_MP_VERSION}}'
       - uses: actions/upload-artifact@v4
         if: failure()
         with:

--- a/pom.xml
+++ b/pom.xml
@@ -75,6 +75,7 @@
         <version.org.wildfly.common>1.7.0.Final</version.org.wildfly.common>
 
         <version.junit>4.13.2</version.junit>
+        <version.org.junit>5.10.2</version.org.junit>
 
         <!-- Test only dependencies -->
         <version.com.github.tomakehurst.wiremock>2.27.2</version.com.github.tomakehurst.wiremock>

--- a/rest-client/pom.xml
+++ b/rest-client/pom.xml
@@ -88,8 +88,8 @@
 
         <!-- Test dependencies -->
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/rest-client/src/test/java/org/jboss/resteasy/microprofile/client/ClientHeadersDefaultFactoryCDITest.java
+++ b/rest-client/src/test/java/org/jboss/resteasy/microprofile/client/ClientHeadersDefaultFactoryCDITest.java
@@ -39,10 +39,10 @@ import org.eclipse.microprofile.rest.client.inject.RestClient;
 import org.jboss.resteasy.plugins.server.undertow.UndertowJaxrsServer;
 import org.jboss.weld.environment.se.Weld;
 import org.jboss.weld.environment.se.WeldContainer;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class ClientHeadersDefaultFactoryCDITest {
 
@@ -104,7 +104,7 @@ public class ClientHeadersDefaultFactoryCDITest {
         }
     }
 
-    @Before
+    @BeforeEach
     public void init() {
         Weld weld = new Weld();
         weld.addBeanClass(Worker.class);
@@ -114,7 +114,7 @@ public class ClientHeadersDefaultFactoryCDITest {
         undertowJaxrsServer.deploy(MyApp.class);
     }
 
-    @After
+    @AfterEach
     public void stop() {
         if (undertowJaxrsServer != null) {
             undertowJaxrsServer.stop();
@@ -127,7 +127,7 @@ public class ClientHeadersDefaultFactoryCDITest {
     @Test
     public void test() {
         String result = weldContainer.select(Worker.class).get().work();
-        Assert.assertTrue(result.contains("IntfHeader: intfValue"));
-        Assert.assertTrue(result.contains("MthdHeader: hello"));
+        Assertions.assertTrue(result.contains("IntfHeader: intfValue"));
+        Assertions.assertTrue(result.contains("MthdHeader: hello"));
     }
 }

--- a/rest-client/src/test/java/org/jboss/resteasy/microprofile/client/ClientHeadersFactoryCDITest.java
+++ b/rest-client/src/test/java/org/jboss/resteasy/microprofile/client/ClientHeadersFactoryCDITest.java
@@ -41,10 +41,10 @@ import org.eclipse.microprofile.rest.client.inject.RestClient;
 import org.jboss.resteasy.plugins.server.undertow.UndertowJaxrsServer;
 import org.jboss.weld.environment.se.Weld;
 import org.jboss.weld.environment.se.WeldContainer;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 public class ClientHeadersFactoryCDITest {
 
@@ -122,7 +122,7 @@ public class ClientHeadersFactoryCDITest {
         }
     }
 
-    @BeforeClass
+    @BeforeAll
     public static void init() {
         Weld weld = new Weld();
         weld.addBeanClass(Worker.class);
@@ -134,7 +134,7 @@ public class ClientHeadersFactoryCDITest {
         server.deploy(MyApp.class);
     }
 
-    @AfterClass
+    @AfterAll
     public static void stop() {
         server.stop();
         container.shutdown();
@@ -142,9 +142,9 @@ public class ClientHeadersFactoryCDITest {
 
     @Test
     public void test() {
-        Assert.assertTrue(container.isRunning());
+        Assertions.assertTrue(container.isRunning());
         String result = container.select(Worker.class).get().work();
-        Assert.assertEquals("hello Stefano", result);
-        Assert.assertEquals(1, Counter.COUNT.get());
+        Assertions.assertEquals("hello Stefano", result);
+        Assertions.assertEquals(1, Counter.COUNT.get());
     }
 }

--- a/rest-client/src/test/java/org/jboss/resteasy/microprofile/client/CloseableClientTest.java
+++ b/rest-client/src/test/java/org/jboss/resteasy/microprofile/client/CloseableClientTest.java
@@ -27,8 +27,8 @@ import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
 
 import org.eclipse.microprofile.rest.client.RestClientBuilder;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
@@ -42,7 +42,7 @@ public class CloseableClientTest {
     public void buildAutoCloseableClientWithUriTemplate() {
         AutoCloseableClientWithUriTemplate client = RestClientBuilder.newBuilder().baseUri(URI.create("http://localhost"))
                 .build(AutoCloseableClientWithUriTemplate.class);
-        Assert.assertNotNull(client);
+        Assertions.assertNotNull(client);
     }
 
     /**
@@ -52,7 +52,7 @@ public class CloseableClientTest {
     public void buildCloseableClientWithUriTemplate() {
         CloseableClientWithUriTemplate client = RestClientBuilder.newBuilder().baseUri(URI.create("http://localhost"))
                 .build(CloseableClientWithUriTemplate.class);
-        Assert.assertNotNull(client);
+        Assertions.assertNotNull(client);
     }
 
     @Path("/{name}")

--- a/rest-client/src/test/java/org/jboss/resteasy/microprofile/client/ProviderFactoryTest.java
+++ b/rest-client/src/test/java/org/jboss/resteasy/microprofile/client/ProviderFactoryTest.java
@@ -24,8 +24,8 @@ import org.jboss.resteasy.client.jaxrs.internal.LocalResteasyProviderFactory;
 import org.jboss.resteasy.plugins.providers.DefaultTextPlain;
 import org.jboss.resteasy.plugins.providers.IIOImageProvider;
 import org.jboss.resteasy.spi.ResteasyProviderFactory;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class ProviderFactoryTest {
 
@@ -33,11 +33,11 @@ public class ProviderFactoryTest {
     public void testDefaultProvider() {
         RestClientBuilderImpl builder = (RestClientBuilderImpl) RestClientBuilder.newBuilder();
 
-        Assert.assertTrue(builder.getBuilderDelegate()
+        Assertions.assertTrue(builder.getBuilderDelegate()
                 .getProviderFactory()
                 .getProviderClasses()
                 .contains(IIOImageProvider.class));
-        Assert.assertTrue(builder.getBuilderDelegate()
+        Assertions.assertTrue(builder.getBuilderDelegate()
                 .getProviderFactory()
                 .getProviderClasses()
                 .contains(DefaultTextPlain.class));
@@ -52,11 +52,11 @@ public class ProviderFactoryTest {
 
             RestClientBuilderImpl builder = (RestClientBuilderImpl) RestClientBuilder.newBuilder();
 
-            Assert.assertTrue(builder.getBuilderDelegate()
+            Assertions.assertTrue(builder.getBuilderDelegate()
                     .getProviderFactory()
                     .getProviderClasses()
                     .contains(IIOImageProvider.class));
-            Assert.assertFalse(builder.getBuilderDelegate()
+            Assertions.assertFalse(builder.getBuilderDelegate()
                     .getProviderFactory()
                     .getProviderClasses()
                     .contains(DefaultTextPlain.class));

--- a/rest-client/src/test/java/org/jboss/resteasy/microprofile/client/RESTEASY_2335_Test.java
+++ b/rest-client/src/test/java/org/jboss/resteasy/microprofile/client/RESTEASY_2335_Test.java
@@ -22,7 +22,7 @@ package org.jboss.resteasy.microprofile.client;
 import java.net.URI;
 
 import org.eclipse.microprofile.rest.client.RestClientBuilder;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class RESTEASY_2335_Test {
     public static final String HTTP_LOCALHOST_8080 = "http://localhost:8080";

--- a/rest-client/src/test/java/org/jboss/resteasy/microprofile/client/headers/ClientHeaderFillingTest.java
+++ b/rest-client/src/test/java/org/jboss/resteasy/microprofile/client/headers/ClientHeaderFillingTest.java
@@ -20,6 +20,7 @@
 package org.jboss.resteasy.microprofile.client.headers;
 
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -34,15 +35,14 @@ import jakarta.ws.rs.core.Application;
 import org.eclipse.microprofile.rest.client.annotation.ClientHeaderParam;
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
 import org.eclipse.microprofile.rest.client.inject.RestClient;
-import org.hamcrest.CoreMatchers;
-import org.hamcrest.MatcherAssert;
 import org.jboss.resteasy.annotations.jaxrs.HeaderParam;
 import org.jboss.resteasy.plugins.server.undertow.UndertowJaxrsServer;
 import org.jboss.weld.environment.se.Weld;
 import org.jboss.weld.environment.se.WeldContainer;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 public class ClientHeaderFillingTest {
     private static final String HEADER_NAME = "GENERATED_HEADER";
@@ -50,7 +50,7 @@ public class ClientHeaderFillingTest {
     private static UndertowJaxrsServer server;
     private static WeldContainer container;
 
-    @BeforeClass
+    @BeforeAll
     public static void init() {
         Weld weld = new Weld();
         weld.addBeanClass(HeaderPassingResource.class);
@@ -64,10 +64,10 @@ public class ClientHeaderFillingTest {
     @Test
     public void checkIfFillerFactoryWithHigherPrioritySelected() {
         List<String> result = container.select(ClientInvokingBean.class).get().getHeaders();
-        MatcherAssert.assertThat(result, CoreMatchers.hasItems("high", "prio"));
+        Assertions.assertTrue(hasItems(result, "high", "prio"));
     }
 
-    @AfterClass
+    @AfterAll
     public static void stop() {
         server.stop();
         container.shutdown();
@@ -114,5 +114,9 @@ public class ClientHeaderFillingTest {
             classes.add(HeaderPassingResource.class);
             return classes;
         }
+    }
+
+    private static boolean hasItems(Collection<String> items, String... controlList) {
+        return items.containsAll(List.of(controlList));
     }
 }

--- a/resteasy-microprofile-test-bom/pom.xml
+++ b/resteasy-microprofile-test-bom/pom.xml
@@ -46,8 +46,8 @@
         <version.org.eclipse.parsson>1.1.4</version.org.eclipse.parsson>
         <version.org.eclipse.yasson>3.0.2</version.org.eclipse.yasson>
 
-        <version.org.jboss.arquillian>1.7.1.Final</version.org.jboss.arquillian>
-        <version.org.jboss.arquillian.container.arquillian-weld-embedded>3.0.2.Final</version.org.jboss.arquillian.container.arquillian-weld-embedded>
+        <version.org.jboss.arquillian>1.7.2.Final</version.org.jboss.arquillian>
+        <version.org.jboss.arquillian.container.arquillian-weld-embedded>4.0.0.Final</version.org.jboss.arquillian.container.arquillian-weld-embedded>
         <version.org.jboss.dmr>1.7.0.Final</version.org.jboss.dmr>
         <version.org.jboss.shrinkwrap.resolver>3.3.0</version.org.jboss.shrinkwrap.resolver>
         <version.org.jboss.weld>5.1.0.Final</version.org.jboss.weld>
@@ -175,9 +175,9 @@
             </dependency>
 
             <dependency>
-                <groupId>junit</groupId>
-                <artifactId>junit</artifactId>
-                <version>${version.junit}</version>
+                <groupId>org.junit.jupiter</groupId>
+                <artifactId>junit-jupiter</artifactId>
+                <version>${version.org.junit}</version>
                 <scope>test</scope>
             </dependency>
 

--- a/testsuite/integration-tests/pom.xml
+++ b/testsuite/integration-tests/pom.xml
@@ -48,6 +48,8 @@
         <feature.pack.artifactId>galleon-feature-pack</feature.pack.artifactId>
         <feature.pack.version>${project.version}</feature.pack.version>
 
+
+        <version.arquillian.junit5>1.7.2.Final</version.arquillian.junit5>
         <jboss.arguments/>
     </properties>
 
@@ -96,8 +98,15 @@
         </dependency>
 
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>${version.org.junit}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jboss.arquillian.junit5</groupId>
+            <artifactId>arquillian-junit5-container</artifactId>
             <scope>test</scope>
         </dependency>
 
@@ -122,12 +131,6 @@
         <dependency>
             <groupId>org.jboss</groupId>
             <artifactId>jboss-dmr</artifactId>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.jboss.arquillian.junit</groupId>
-            <artifactId>arquillian-junit-container</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/microprofile/test/client/exception/ClientWebApplicationExceptionMicroProfileProxyTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/microprofile/test/client/exception/ClientWebApplicationExceptionMicroProfileProxyTest.java
@@ -29,7 +29,7 @@ import jakarta.ws.rs.core.Response;
 import org.eclipse.microprofile.rest.client.RestClientBuilder;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.resteasy.client.exception.ResteasyWebApplicationException;
 import org.jboss.resteasy.microprofile.test.client.exception.resource.ClientWebApplicationExceptionMicroProfileProxyApplication;
@@ -39,11 +39,11 @@ import org.jboss.resteasy.microprofile.test.util.TestEnvironment;
 import org.jboss.resteasy.utils.PermissionUtil;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * @tpSubChapter Resteasy-client
@@ -57,7 +57,7 @@ import org.junit.runner.RunWith;
  *                    and WebApplicationExceptionWrappers, MicroProfile REST Client proxies throw only WebApplicationExceptions
  *                    and WebApplicationExceptionWrappers.
  */
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 @RunAsClient
 public class ClientWebApplicationExceptionMicroProfileProxyTest {
 
@@ -86,7 +86,7 @@ public class ClientWebApplicationExceptionMicroProfileProxyTest {
                         "permissions.xml");
     }
 
-    @Before
+    @BeforeEach
     public void createProxy() throws Exception {
         proxy = RestClientBuilder.newBuilder()
                 .baseUri(TestEnvironment.generateUri(url, "/app/test/"))
@@ -106,36 +106,36 @@ public class ClientWebApplicationExceptionMicroProfileProxyTest {
         for (int i = 1; i < ClientWebApplicationExceptionConstants.oldExceptions.length; i++) {
             try {
                 proxy.oldException(i);
-                Assert.fail("expected exception");
+                Assertions.fail("expected exception");
             } catch (ResteasyWebApplicationException rwae) {
-                Assert.fail("Didn't expect ResteasyWebApplicationException");
+                Assertions.fail("Didn't expect ResteasyWebApplicationException");
             } catch (WebApplicationException wae) {
                 Response response = wae.getResponse();
                 WebApplicationException oldException = ClientWebApplicationExceptionConstants.oldExceptions[i];
-                Assert.assertEquals(oldException.getResponse().getStatus(), response.getStatus());
-                Assert.assertEquals(oldException.getResponse().getHeaderString("foo"), response.getHeaderString("foo"));
-                Assert.assertEquals(oldException.getResponse().getEntity(), response.readEntity(String.class));
-                Assert.assertEquals(WebApplicationException.class, wae.getClass());
+                Assertions.assertEquals(oldException.getResponse().getStatus(), response.getStatus());
+                Assertions.assertEquals(oldException.getResponse().getHeaderString("foo"), response.getHeaderString("foo"));
+                Assertions.assertEquals(oldException.getResponse().getEntity(), response.readEntity(String.class));
+                Assertions.assertEquals(WebApplicationException.class, wae.getClass());
             } catch (Exception e) {
-                Assert.fail("expected WebApplicationException");
+                Assertions.fail("expected WebApplicationException");
             }
         }
         // DefaultResponseExceptionMapper on client side doesn't handle status s, 300 <= s < 400, and
         // ClientInvocation creates a RedirectionException.
         try {
             proxy.oldException(0);
-            Assert.fail("expected exception");
+            Assertions.fail("expected exception");
         } catch (ResteasyWebApplicationException rwae) {
-            Assert.fail("Didn't expect ResteasyWebApplicationException");
+            Assertions.fail("Didn't expect ResteasyWebApplicationException");
         } catch (WebApplicationException wae) {
             Response response = wae.getResponse();
             WebApplicationException oldException = ClientWebApplicationExceptionConstants.oldExceptions[0];
-            Assert.assertEquals(oldException.getResponse().getStatus(), response.getStatus());
-            Assert.assertEquals(oldException.getResponse().getHeaderString("foo"), response.getHeaderString("foo"));
-            Assert.assertEquals(oldException.getResponse().getEntity(), response.readEntity(String.class));
-            Assert.assertEquals(RedirectionException.class, wae.getClass());
+            Assertions.assertEquals(oldException.getResponse().getStatus(), response.getStatus());
+            Assertions.assertEquals(oldException.getResponse().getHeaderString("foo"), response.getHeaderString("foo"));
+            Assertions.assertEquals(oldException.getResponse().getEntity(), response.readEntity(String.class));
+            Assertions.assertEquals(RedirectionException.class, wae.getClass());
         } catch (Exception e) {
-            Assert.fail("expected WebApplicationException");
+            Assertions.fail("expected WebApplicationException");
         }
     }
 
@@ -152,36 +152,36 @@ public class ClientWebApplicationExceptionMicroProfileProxyTest {
         for (int i = 1; i < ClientWebApplicationExceptionConstants.newExceptions.length; i++) {
             try {
                 proxy.newException(i);
-                Assert.fail("expected exception");
+                Assertions.fail("expected exception");
             } catch (ResteasyWebApplicationException rwae) {
-                Assert.fail("Didn't expect ResteasyWebApplicationException");
+                Assertions.fail("Didn't expect ResteasyWebApplicationException");
             } catch (WebApplicationException e) {
                 final String msg = String.format("Failed on %d: %s", i, ClientWebApplicationExceptionConstants.newExceptions[i]
                         .getResponse());
                 Response response = e.getResponse();
-                Assert.assertEquals(msg, ClientWebApplicationExceptionConstants.newExceptions[i].getResponse()
-                        .getStatus(), response.getStatus());
-                Assert.assertNull(msg, response.getHeaderString("foo"));
-                Assert.assertTrue(msg, response.readEntity(String.class).isEmpty());
-                Assert.assertEquals(msg, WebApplicationException.class, e.getClass());
+                Assertions.assertEquals(ClientWebApplicationExceptionConstants.newExceptions[i].getResponse()
+                        .getStatus(), response.getStatus(), msg);
+                Assertions.assertNull(response.getHeaderString("foo"), msg);
+                Assertions.assertTrue(response.readEntity(String.class).isEmpty(), msg);
+                Assertions.assertEquals(WebApplicationException.class, e.getClass(), msg);
             }
         }
         // DefaultResponseExceptionMapper on client side doesn't handle status s, 300 <= s < 400, and
         // ClientInvocation creates a RedirectionException.
         try {
             proxy.newException(0);
-            Assert.fail("expected exception");
+            Assertions.fail("expected exception");
         } catch (ResteasyWebApplicationException rwae) {
-            Assert.fail("Didn't expect ResteasyWebApplicationException");
+            Assertions.fail("Didn't expect ResteasyWebApplicationException");
         } catch (WebApplicationException e) {
             final String msg = String.format("Failed on %d: %s", 0, ClientWebApplicationExceptionConstants.newExceptions[0]
                     .getResponse());
             Response response = e.getResponse();
-            Assert.assertEquals(msg, ClientWebApplicationExceptionConstants.newExceptions[0].getResponse()
-                    .getStatus(), response.getStatus());
-            Assert.assertNull(msg, response.getHeaderString("foo"));
-            Assert.assertTrue(msg, response.readEntity(String.class).isEmpty());
-            Assert.assertEquals(msg, RedirectionException.class, e.getClass());
+            Assertions.assertEquals(ClientWebApplicationExceptionConstants.newExceptions[0].getResponse()
+                    .getStatus(), response.getStatus(), msg);
+            Assertions.assertNull(response.getHeaderString("foo"), msg);
+            Assertions.assertTrue(response.readEntity(String.class).isEmpty(), msg);
+            Assertions.assertEquals(RedirectionException.class, e.getClass(), msg);
         }
     }
 
@@ -212,36 +212,36 @@ public class ClientWebApplicationExceptionMicroProfileProxyTest {
             for (int i = 1; i < ClientWebApplicationExceptionConstants.oldExceptions.length; i++) {
                 try {
                     proxy.noCatchOld(i);
-                    Assert.fail("expected exception");
+                    Assertions.fail("expected exception");
                 } catch (ResteasyWebApplicationException e) {
-                    Assert.fail("didn't expect ResteasyWebApplicationException");
+                    Assertions.fail("didn't expect ResteasyWebApplicationException");
                 } catch (WebApplicationException e) {
                     Response response = e.getResponse();
                     WebApplicationException wae = ClientWebApplicationExceptionConstants.oldExceptions[i];
-                    Assert.assertEquals(wae.getResponse().getStatus(), response.getStatus());
-                    Assert.assertEquals(wae.getResponse().getHeaderString("foo"), response.getHeaderString("foo"));
-                    Assert.assertEquals(wae.getResponse().getEntity(), response.readEntity(String.class));
-                    Assert.assertEquals(WebApplicationException.class, e.getClass());
+                    Assertions.assertEquals(wae.getResponse().getStatus(), response.getStatus());
+                    Assertions.assertEquals(wae.getResponse().getHeaderString("foo"), response.getHeaderString("foo"));
+                    Assertions.assertEquals(wae.getResponse().getEntity(), response.readEntity(String.class));
+                    Assertions.assertEquals(WebApplicationException.class, e.getClass());
                 } catch (Exception e) {
-                    Assert.fail("expected WebApplicationException");
+                    Assertions.fail("expected WebApplicationException");
                 }
             }
             // DefaultResponseExceptionMapper on client side doesn't handle status s, 300 <= s < 400, and
             // ClientInvocation creates a RedirectionException.
             try {
                 proxy.noCatchOld(0);
-                Assert.fail("expected exception");
+                Assertions.fail("expected exception");
             } catch (ResteasyWebApplicationException e) {
-                Assert.fail("didn't expect ResteasyWebApplicationException");
+                Assertions.fail("didn't expect ResteasyWebApplicationException");
             } catch (WebApplicationException e) {
                 Response response = e.getResponse();
                 WebApplicationException wae = ClientWebApplicationExceptionConstants.oldExceptions[0];
-                Assert.assertEquals(wae.getResponse().getStatus(), response.getStatus());
-                Assert.assertEquals(wae.getResponse().getHeaderString("foo"), response.getHeaderString("foo"));
-                Assert.assertEquals(wae.getResponse().getEntity(), response.readEntity(String.class));
-                Assert.assertEquals(RedirectionException.class, e.getClass());
+                Assertions.assertEquals(wae.getResponse().getStatus(), response.getStatus());
+                Assertions.assertEquals(wae.getResponse().getHeaderString("foo"), response.getHeaderString("foo"));
+                Assertions.assertEquals(wae.getResponse().getEntity(), response.readEntity(String.class));
+                Assertions.assertEquals(RedirectionException.class, e.getClass());
             } catch (Exception e) {
-                Assert.fail("expected WebApplicationException");
+                Assertions.fail("expected WebApplicationException");
             }
         } finally {
             proxy.setBehavior("false");
@@ -273,36 +273,36 @@ public class ClientWebApplicationExceptionMicroProfileProxyTest {
             for (int i = 1; i < ClientWebApplicationExceptionConstants.newExceptions.length; i++) {
                 try {
                     proxy.noCatchNew(i);
-                    Assert.fail("expected exception");
+                    Assertions.fail("expected exception");
                 } catch (ResteasyWebApplicationException e) {
-                    Assert.fail("didn't expect ResteasyWebApplicationException");
+                    Assertions.fail("didn't expect ResteasyWebApplicationException");
                 } catch (WebApplicationException e) {
                     Response response = e.getResponse();
-                    Assert.assertEquals(ClientWebApplicationExceptionConstants.newExceptions[i].getResponse()
+                    Assertions.assertEquals(ClientWebApplicationExceptionConstants.newExceptions[i].getResponse()
                             .getStatus(), response.getStatus());
-                    Assert.assertNull(response.getHeaderString("foo"));
-                    Assert.assertTrue(response.readEntity(String.class).isEmpty());
-                    Assert.assertEquals(WebApplicationException.class, e.getClass());
+                    Assertions.assertNull(response.getHeaderString("foo"));
+                    Assertions.assertTrue(response.readEntity(String.class).isEmpty());
+                    Assertions.assertEquals(WebApplicationException.class, e.getClass());
                 } catch (Exception e) {
-                    Assert.fail("expected WebApplicationException");
+                    Assertions.fail("expected WebApplicationException");
                 }
             }
             // DefaultResponseExceptionMapper on client side doesn't handle status s, 300 <= s < 400, and
             // ClientInvocation creates a RedirectionException.
             try {
                 proxy.noCatchNew(0);
-                Assert.fail("expected exception");
+                Assertions.fail("expected exception");
             } catch (ResteasyWebApplicationException e) {
-                Assert.fail("didn't expect ResteasyWebApplicationException");
+                Assertions.fail("didn't expect ResteasyWebApplicationException");
             } catch (WebApplicationException e) {
                 Response response = e.getResponse();
-                Assert.assertEquals(ClientWebApplicationExceptionConstants.newExceptions[0].getResponse()
+                Assertions.assertEquals(ClientWebApplicationExceptionConstants.newExceptions[0].getResponse()
                         .getStatus(), response.getStatus());
-                Assert.assertNull(response.getHeaderString("foo"));
-                Assert.assertTrue(response.readEntity(String.class).isEmpty());
-                Assert.assertEquals(RedirectionException.class, e.getClass());
+                Assertions.assertNull(response.getHeaderString("foo"));
+                Assertions.assertTrue(response.readEntity(String.class).isEmpty());
+                Assertions.assertEquals(RedirectionException.class, e.getClass());
             } catch (Exception e) {
-                Assert.fail("expected WebApplicationException");
+                Assertions.fail("expected WebApplicationException");
             }
         } finally {
             proxy.setBehavior("false");
@@ -328,36 +328,36 @@ public class ClientWebApplicationExceptionMicroProfileProxyTest {
         for (int i = 1; i < ClientWebApplicationExceptionConstants.oldExceptions.length; i++) {
             try {
                 proxy.noCatchOld(i);
-                Assert.fail("expected exception");
+                Assertions.fail("expected exception");
             } catch (ResteasyWebApplicationException e) {
-                Assert.fail("didn't expect ResteasyWebApplicationException");
+                Assertions.fail("didn't expect ResteasyWebApplicationException");
             } catch (WebApplicationException e) {
                 Response response = e.getResponse();
-                Assert.assertEquals(ClientWebApplicationExceptionConstants.oldExceptions[i].getResponse()
+                Assertions.assertEquals(ClientWebApplicationExceptionConstants.oldExceptions[i].getResponse()
                         .getStatus(), response.getStatus());
-                Assert.assertNull(response.getHeaderString("foo"));
-                Assert.assertTrue(response.readEntity(String.class).isEmpty());
-                Assert.assertEquals(WebApplicationException.class, e.getClass());
+                Assertions.assertNull(response.getHeaderString("foo"));
+                Assertions.assertTrue(response.readEntity(String.class).isEmpty());
+                Assertions.assertEquals(WebApplicationException.class, e.getClass());
             } catch (Exception e) {
-                Assert.fail("expected WebApplicationException");
+                Assertions.fail("expected WebApplicationException");
             }
         }
         // DefaultResponseExceptionMapper on client side doesn't handle status s, 300 <= s < 400, and
         // ClientInvocation creates a RedirectionException.
         try {
             proxy.noCatchOld(0);
-            Assert.fail("expected exception");
+            Assertions.fail("expected exception");
         } catch (ResteasyWebApplicationException e) {
-            Assert.fail("didn't expect ResteasyWebApplicationException");
+            Assertions.fail("didn't expect ResteasyWebApplicationException");
         } catch (WebApplicationException e) {
             Response response = e.getResponse();
-            Assert.assertEquals(ClientWebApplicationExceptionConstants.oldExceptions[0].getResponse()
+            Assertions.assertEquals(ClientWebApplicationExceptionConstants.oldExceptions[0].getResponse()
                     .getStatus(), response.getStatus());
-            Assert.assertNull(response.getHeaderString("foo"));
-            Assert.assertTrue(response.readEntity(String.class).isEmpty());
-            Assert.assertEquals(RedirectionException.class, e.getClass());
+            Assertions.assertNull(response.getHeaderString("foo"));
+            Assertions.assertTrue(response.readEntity(String.class).isEmpty());
+            Assertions.assertEquals(RedirectionException.class, e.getClass());
         } catch (Exception e) {
-            Assert.fail("expected WebApplicationException");
+            Assertions.fail("expected WebApplicationException");
         }
     }
 
@@ -380,36 +380,36 @@ public class ClientWebApplicationExceptionMicroProfileProxyTest {
         for (int i = 1; i < ClientWebApplicationExceptionConstants.newExceptions.length; i++) {
             try {
                 proxy.noCatchNew(i);
-                Assert.fail("expected exception");
+                Assertions.fail("expected exception");
             } catch (ResteasyWebApplicationException e) {
-                Assert.fail("didn't expect ResteasyWebApplicationException");
+                Assertions.fail("didn't expect ResteasyWebApplicationException");
             } catch (WebApplicationException e) {
                 Response response = e.getResponse();
-                Assert.assertEquals(ClientWebApplicationExceptionConstants.newExceptions[i].getResponse()
+                Assertions.assertEquals(ClientWebApplicationExceptionConstants.newExceptions[i].getResponse()
                         .getStatus(), response.getStatus());
-                Assert.assertNull(response.getHeaderString("foo"));
-                Assert.assertTrue(response.readEntity(String.class).isEmpty());
-                Assert.assertEquals(WebApplicationException.class, e.getClass());
+                Assertions.assertNull(response.getHeaderString("foo"));
+                Assertions.assertTrue(response.readEntity(String.class).isEmpty());
+                Assertions.assertEquals(WebApplicationException.class, e.getClass());
             } catch (Exception e) {
-                Assert.fail("expected WebApplicationException");
+                Assertions.fail("expected WebApplicationException");
             }
         }
         // DefaultResponseExceptionMapper on client side doesn't handle status s, 300 <= s < 400, and
         // ClientInvocation creates a RedirectionException.
         try {
             proxy.noCatchNew(0);
-            Assert.fail("expected exception");
+            Assertions.fail("expected exception");
         } catch (ResteasyWebApplicationException e) {
-            Assert.fail("didn't expect ResteasyWebApplicationException");
+            Assertions.fail("didn't expect ResteasyWebApplicationException");
         } catch (WebApplicationException e) {
             Response response = e.getResponse();
-            Assert.assertEquals(ClientWebApplicationExceptionConstants.newExceptions[0].getResponse()
+            Assertions.assertEquals(ClientWebApplicationExceptionConstants.newExceptions[0].getResponse()
                     .getStatus(), response.getStatus());
-            Assert.assertNull(response.getHeaderString("foo"));
-            Assert.assertTrue(response.readEntity(String.class).isEmpty());
-            Assert.assertEquals(RedirectionException.class, e.getClass());
+            Assertions.assertNull(response.getHeaderString("foo"));
+            Assertions.assertTrue(response.readEntity(String.class).isEmpty());
+            Assertions.assertEquals(RedirectionException.class, e.getClass());
         } catch (Exception e) {
-            Assert.fail("expected WebApplicationException");
+            Assertions.fail("expected WebApplicationException");
         }
     }
 
@@ -440,40 +440,40 @@ public class ClientWebApplicationExceptionMicroProfileProxyTest {
             for (int i = 1; i < ClientWebApplicationExceptionConstants.oldExceptions.length; i++) {
                 try {
                     proxy.catchOldOld(i);
-                    Assert.fail("expected exception");
+                    Assertions.fail("expected exception");
                 } catch (ResteasyWebApplicationException e) {
-                    Assert.fail("didn't expect ResteasyWebApplicationException");
+                    Assertions.fail("didn't expect ResteasyWebApplicationException");
                 } catch (WebApplicationException e) {
                     Response response = e.getResponse();
-                    Assert.assertEquals(ClientWebApplicationExceptionConstants.oldExceptions[i].getResponse()
+                    Assertions.assertEquals(ClientWebApplicationExceptionConstants.oldExceptions[i].getResponse()
                             .getStatus(), response.getStatus());
-                    Assert.assertEquals(ClientWebApplicationExceptionConstants.oldExceptions[i].getResponse()
+                    Assertions.assertEquals(ClientWebApplicationExceptionConstants.oldExceptions[i].getResponse()
                             .getHeaderString("foo"), response.getHeaderString("foo"));
-                    Assert.assertEquals(ClientWebApplicationExceptionConstants.oldExceptions[i].getResponse()
+                    Assertions.assertEquals(ClientWebApplicationExceptionConstants.oldExceptions[i].getResponse()
                             .getEntity(), response.readEntity(String.class));
-                    Assert.assertEquals(WebApplicationException.class, e.getClass());
+                    Assertions.assertEquals(WebApplicationException.class, e.getClass());
                 } catch (Exception e) {
-                    Assert.fail("expected WebApplicationException");
+                    Assertions.fail("expected WebApplicationException");
                 }
             }
             // DefaultResponseExceptionMapper on client side doesn't handle status s, 300 <= s < 400, and
             // ClientInvocation creates a RedirectionException.
             try {
                 proxy.catchOldOld(0);
-                Assert.fail("expected exception");
+                Assertions.fail("expected exception");
             } catch (ResteasyWebApplicationException e) {
-                Assert.fail("didn't expect ResteasyWebApplicationException");
+                Assertions.fail("didn't expect ResteasyWebApplicationException");
             } catch (WebApplicationException e) {
                 Response response = e.getResponse();
-                Assert.assertEquals(ClientWebApplicationExceptionConstants.oldExceptions[0].getResponse()
+                Assertions.assertEquals(ClientWebApplicationExceptionConstants.oldExceptions[0].getResponse()
                         .getStatus(), response.getStatus());
-                Assert.assertEquals(ClientWebApplicationExceptionConstants.oldExceptions[0].getResponse()
+                Assertions.assertEquals(ClientWebApplicationExceptionConstants.oldExceptions[0].getResponse()
                         .getHeaderString("foo"), response.getHeaderString("foo"));
-                Assert.assertEquals(ClientWebApplicationExceptionConstants.oldExceptions[0].getResponse()
+                Assertions.assertEquals(ClientWebApplicationExceptionConstants.oldExceptions[0].getResponse()
                         .getEntity(), response.readEntity(String.class));
-                Assert.assertEquals(RedirectionException.class, e.getClass());
+                Assertions.assertEquals(RedirectionException.class, e.getClass());
             } catch (Exception e) {
-                Assert.fail("expected WebApplicationException");
+                Assertions.fail("expected WebApplicationException");
             }
         } finally {
             proxy.setBehavior("false");
@@ -505,38 +505,38 @@ public class ClientWebApplicationExceptionMicroProfileProxyTest {
             for (int i = 1; i < ClientWebApplicationExceptionConstants.newExceptions.length; i++) {
                 try {
                     proxy.catchOldNew(i);
-                    Assert.fail("expected exception");
+                    Assertions.fail("expected exception");
                 } catch (ResteasyWebApplicationException e) {
-                    Assert.fail("didn't expect ResteasyWebApplicationException");
+                    Assertions.fail("didn't expect ResteasyWebApplicationException");
                 } catch (WebApplicationException e) {
                     Response response = e.getResponse();
-                    Assert.assertNotNull(response);
-                    Assert.assertEquals(ClientWebApplicationExceptionConstants.newExceptions[i].getResponse()
+                    Assertions.assertNotNull(response);
+                    Assertions.assertEquals(ClientWebApplicationExceptionConstants.newExceptions[i].getResponse()
                             .getStatus(), response.getStatus());
-                    Assert.assertNull(response.getHeaderString("foo"));
-                    Assert.assertTrue(response.readEntity(String.class).length() == 0);
-                    Assert.assertEquals(WebApplicationException.class, e.getClass());
+                    Assertions.assertNull(response.getHeaderString("foo"));
+                    Assertions.assertTrue(response.readEntity(String.class).length() == 0);
+                    Assertions.assertEquals(WebApplicationException.class, e.getClass());
                 } catch (Exception e) {
-                    Assert.fail("expected WebApplicationException");
+                    Assertions.fail("expected WebApplicationException");
                 }
             }
             // DefaultResponseExceptionMapper on client side doesn't handle status s, 300 <= s < 400, and
             // ClientInvocation creates a RedirectionException.
             try {
                 proxy.catchOldNew(0);
-                Assert.fail("expected exception");
+                Assertions.fail("expected exception");
             } catch (ResteasyWebApplicationException e) {
-                Assert.fail("didn't expect ResteasyWebApplicationException");
+                Assertions.fail("didn't expect ResteasyWebApplicationException");
             } catch (WebApplicationException e) {
                 Response response = e.getResponse();
-                Assert.assertNotNull(response);
-                Assert.assertEquals(ClientWebApplicationExceptionConstants.newExceptions[0].getResponse()
+                Assertions.assertNotNull(response);
+                Assertions.assertEquals(ClientWebApplicationExceptionConstants.newExceptions[0].getResponse()
                         .getStatus(), response.getStatus());
-                Assert.assertNull(response.getHeaderString("foo"));
-                Assert.assertTrue(response.readEntity(String.class).length() == 0);
-                Assert.assertEquals(RedirectionException.class, e.getClass());
+                Assertions.assertNull(response.getHeaderString("foo"));
+                Assertions.assertTrue(response.readEntity(String.class).length() == 0);
+                Assertions.assertEquals(RedirectionException.class, e.getClass());
             } catch (Exception e) {
-                Assert.fail("expected WebApplicationException");
+                Assertions.fail("expected WebApplicationException");
             }
         } finally {
             proxy.setBehavior("false");
@@ -558,41 +558,41 @@ public class ClientWebApplicationExceptionMicroProfileProxyTest {
      * @tpSince RESTEasy 4.6.0.Final
      */
     @Test
-    @Ignore("This test does not work for some reason.")
+    @Disabled("This test does not work for some reason.")
     public void testCatchNewBehaviorOldExceptions() {
         for (int i = 1; i < ClientWebApplicationExceptionConstants.oldExceptions.length; i++) {
             try {
                 proxy.catchNewOld(i);
-                Assert.fail("expected exception");
+                Assertions.fail("expected exception");
             } catch (ResteasyWebApplicationException e) {
-                Assert.fail("didn't expect ResteasyWebApplicationException");
+                Assertions.fail("didn't expect ResteasyWebApplicationException");
             } catch (WebApplicationException e) {
                 Response response = e.getResponse();
-                Assert.assertNotNull(response);
-                Assert.assertEquals(ClientWebApplicationExceptionConstants.oldExceptions[i].getResponse()
+                Assertions.assertNotNull(response);
+                Assertions.assertEquals(ClientWebApplicationExceptionConstants.oldExceptions[i].getResponse()
                         .getStatus(), response.getStatus());
-                Assert.assertNull(response.getHeaderString("foo"));
-                Assert.assertTrue(response.readEntity(String.class).isEmpty());
-                Assert.assertEquals(ClientWebApplicationExceptionConstants.oldExceptions[i].getClass(), e.getClass());
+                Assertions.assertNull(response.getHeaderString("foo"));
+                Assertions.assertTrue(response.readEntity(String.class).isEmpty());
+                Assertions.assertEquals(ClientWebApplicationExceptionConstants.oldExceptions[i].getClass(), e.getClass());
             } catch (Exception e) {
-                Assert.fail("expected WebApplicationException");
+                Assertions.fail("expected WebApplicationException");
             }
         }
         try {
             proxy.catchNewOld(0);
-            Assert.fail("expected exception");
+            Assertions.fail("expected exception");
         } catch (ResteasyWebApplicationException e) {
-            Assert.fail("didn't expect ResteasyWebApplicationException");
+            Assertions.fail("didn't expect ResteasyWebApplicationException");
         } catch (WebApplicationException e) {
             Response response = e.getResponse();
-            Assert.assertNotNull(response);
-            Assert.assertEquals(ClientWebApplicationExceptionConstants.oldExceptions[0].getResponse()
+            Assertions.assertNotNull(response);
+            Assertions.assertEquals(ClientWebApplicationExceptionConstants.oldExceptions[0].getResponse()
                     .getStatus(), response.getStatus());
-            Assert.assertNull(response.getHeaderString("foo"));
-            Assert.assertTrue(response.readEntity(String.class).isEmpty());
-            Assert.assertEquals(RedirectionException.class, e.getClass());
+            Assertions.assertNull(response.getHeaderString("foo"));
+            Assertions.assertTrue(response.readEntity(String.class).isEmpty());
+            Assertions.assertEquals(RedirectionException.class, e.getClass());
         } catch (Exception e) {
-            Assert.fail("expected WebApplicationException");
+            Assertions.fail("expected WebApplicationException");
         }
     }
 
@@ -611,41 +611,41 @@ public class ClientWebApplicationExceptionMicroProfileProxyTest {
      * @tpSince RESTEasy 4.6.0.Final
      */
     @Test
-    @Ignore("This test does not work for some reason.")
+    @Disabled("This test does not work for some reason.")
     public void testCatchNewBehaviorNewExceptions() {
         for (int i = 1; i < ClientWebApplicationExceptionConstants.newExceptions.length; i++) {
             try {
                 proxy.catchNewNew(i);
-                Assert.fail("expected exception");
+                Assertions.fail("expected exception");
             } catch (ResteasyWebApplicationException e) {
-                Assert.fail("didn't expect ResteasyWebApplicationException");
+                Assertions.fail("didn't expect ResteasyWebApplicationException");
             } catch (WebApplicationException e) {
                 Response response = e.getResponse();
-                Assert.assertNotNull(response);
-                Assert.assertEquals(ClientWebApplicationExceptionConstants.oldExceptions[i].getResponse()
+                Assertions.assertNotNull(response);
+                Assertions.assertEquals(ClientWebApplicationExceptionConstants.oldExceptions[i].getResponse()
                         .getStatus(), response.getStatus());
-                Assert.assertNull(response.getHeaderString("foo"));
-                Assert.assertTrue(response.readEntity(String.class).isEmpty());
-                Assert.assertEquals(ClientWebApplicationExceptionConstants.oldExceptions[i].getClass(), e.getClass());
+                Assertions.assertNull(response.getHeaderString("foo"));
+                Assertions.assertTrue(response.readEntity(String.class).isEmpty());
+                Assertions.assertEquals(ClientWebApplicationExceptionConstants.oldExceptions[i].getClass(), e.getClass());
             } catch (Exception e) {
-                Assert.fail("expected WebApplicationException");
+                Assertions.fail("expected WebApplicationException");
             }
         }
         try {
             proxy.catchNewNew(0);
-            Assert.fail("expected exception");
+            Assertions.fail("expected exception");
         } catch (ResteasyWebApplicationException e) {
-            Assert.fail("didn't expect ResteasyWebApplicationException: " + e.getClass());
+            Assertions.fail("didn't expect ResteasyWebApplicationException: " + e.getClass());
         } catch (WebApplicationException e) {
             Response response = e.getResponse();
-            Assert.assertNotNull(response);
-            Assert.assertEquals(ClientWebApplicationExceptionConstants.oldExceptions[0].getResponse()
+            Assertions.assertNotNull(response);
+            Assertions.assertEquals(ClientWebApplicationExceptionConstants.oldExceptions[0].getResponse()
                     .getStatus(), response.getStatus());
-            Assert.assertNull(response.getHeaderString("foo"));
-            Assert.assertTrue(response.readEntity(String.class).isEmpty());
-            Assert.assertEquals(RedirectionException.class, e.getClass());
+            Assertions.assertNull(response.getHeaderString("foo"));
+            Assertions.assertTrue(response.readEntity(String.class).isEmpty());
+            Assertions.assertEquals(RedirectionException.class, e.getClass());
         } catch (Exception e) {
-            Assert.fail("expected WebApplicationException");
+            Assertions.fail("expected WebApplicationException");
         }
     }
 }

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/microprofile/test/client/exception/ResponseExceptionMapperRuntimeExceptionTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/microprofile/test/client/exception/ResponseExceptionMapperRuntimeExceptionTest.java
@@ -19,7 +19,7 @@
 
 package org.jboss.resteasy.microprofile.test.client.exception;
 
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.net.URL;
 
@@ -29,7 +29,7 @@ import org.eclipse.microprofile.rest.client.RestClientBuilder;
 import org.eclipse.microprofile.rest.client.ext.ResponseExceptionMapper;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.resteasy.microprofile.test.client.exception.resource.ExceptionMapperRuntimeExceptionWithReasonMapper;
 import org.jboss.resteasy.microprofile.test.client.exception.resource.ResponseExceptionMapperRuntimeExceptionMapper;
@@ -38,9 +38,9 @@ import org.jboss.resteasy.microprofile.test.client.exception.resource.ResponseEx
 import org.jboss.resteasy.microprofile.test.util.TestEnvironment;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * @tpSubChapter Resteasy-client
@@ -48,7 +48,7 @@ import org.junit.runner.RunWith;
  * @tpSince RESTEasy 3.6.0
  * @tpTestCaseDetails Regression test for RESTEASY-1847
  */
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 @RunAsClient
 public class ResponseExceptionMapperRuntimeExceptionTest {
 
@@ -82,7 +82,7 @@ public class ResponseExceptionMapperRuntimeExceptionTest {
             fail("Should not get here");
         } catch (RuntimeException e) {
             // assert test exception message
-            Assert.assertEquals(ExceptionMapperRuntimeExceptionWithReasonMapper.REASON, e.getMessage());
+            Assertions.assertEquals(ExceptionMapperRuntimeExceptionWithReasonMapper.REASON, e.getMessage());
         }
     }
 
@@ -97,7 +97,7 @@ public class ResponseExceptionMapperRuntimeExceptionTest {
             fail("Should not get here");
         } catch (WebApplicationException e) {
             String str = e.getResponse().readEntity(String.class);
-            Assert.assertEquals("Test error occurred", str);
+            Assertions.assertEquals("Test error occurred", str);
         }
     }
 

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/microprofile/test/client/exception/SubResourceTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/microprofile/test/client/exception/SubResourceTest.java
@@ -29,7 +29,7 @@ import jakarta.ws.rs.core.Response;
 import org.eclipse.microprofile.rest.client.RestClientBuilder;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.resteasy.microprofile.test.client.exception.resource.ClientRootResource;
 import org.jboss.resteasy.microprofile.test.client.exception.resource.ClientSubResource;
@@ -38,16 +38,16 @@ import org.jboss.resteasy.microprofile.test.client.exception.resource.TestExcept
 import org.jboss.resteasy.microprofile.test.client.exception.resource.TestExceptionMapper;
 import org.jboss.resteasy.microprofile.test.util.TestEnvironment;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * Tests client sub-resources
  *
  * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
  */
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 @RunAsClient
 public class SubResourceTest {
 
@@ -70,9 +70,9 @@ public class SubResourceTest {
     public void rootResourceExceptionMapper() throws Exception {
         try (ClientRootResource root = createClient(TestExceptionMapper.class)) {
             try (Response ignore = root.fromRoot()) {
-                Assert.fail("fromRoot() should have thrown an TestException");
+                Assertions.fail("fromRoot() should have thrown an TestException");
             } catch (TestException expected) {
-                Assert.assertEquals("RootResource failed on purpose", expected.getMessage());
+                Assertions.assertEquals("RootResource failed on purpose", expected.getMessage());
             } catch (Exception e) {
                 failWithException(e, "fromRoot");
             }
@@ -90,11 +90,11 @@ public class SubResourceTest {
     public void subResourceExceptionMapper() throws Exception {
         try (ClientRootResource root = createClient(TestExceptionMapper.class)) {
             final ClientSubResource subResource = root.subResource();
-            Assert.assertNotNull("The SubResource should not be null", subResource);
+            Assertions.assertNotNull(subResource, "The SubResource should not be null");
             try (Response ignore = subResource.fromSub()) {
-                Assert.fail("fromSub() should have thrown an TestException");
+                Assertions.fail("fromSub() should have thrown an TestException");
             } catch (TestException expected) {
-                Assert.assertEquals("SubResource failed on purpose", expected.getMessage());
+                Assertions.assertEquals("SubResource failed on purpose", expected.getMessage());
             } catch (Exception e) {
                 failWithException(e, "fromSub");
             }
@@ -111,11 +111,11 @@ public class SubResourceTest {
     public void subResourceWithHeader() throws Exception {
         try (ClientRootResource root = createClient()) {
             final ClientSubResource subResource = root.subResource();
-            Assert.assertNotNull("The SubResource should not be null", subResource);
+            Assertions.assertNotNull(subResource, "The SubResource should not be null");
             try (Response response = subResource.withHeader()) {
-                Assert.assertEquals(Response.Status.OK, response.getStatusInfo());
+                Assertions.assertEquals(Response.Status.OK, response.getStatusInfo());
                 final String value = response.readEntity(String.class);
-                Assert.assertEquals("SubResourceHeader", value);
+                Assertions.assertEquals("SubResourceHeader", value);
             }
         }
     }
@@ -130,11 +130,11 @@ public class SubResourceTest {
     public void subResourceWithGlobalHeader() throws Exception {
         try (ClientRootResource root = createClient()) {
             final ClientSubResource subResource = root.subResource();
-            Assert.assertNotNull("The SubResource should not be null", subResource);
+            Assertions.assertNotNull(subResource, "The SubResource should not be null");
             try (Response response = subResource.withGlobalHeader()) {
-                Assert.assertEquals(Response.Status.OK, response.getStatusInfo());
+                Assertions.assertEquals(Response.Status.OK, response.getStatusInfo());
                 final String value = response.readEntity(String.class);
-                Assert.assertEquals("GlobalSubResourceHeader", value);
+                Assertions.assertEquals("GlobalSubResourceHeader", value);
             }
         }
     }
@@ -158,6 +158,6 @@ public class SubResourceTest {
         writer.write("() should have thrown an TestException. Instead got: ");
         writer.write(System.lineSeparator());
         e.printStackTrace(new PrintWriter(writer));
-        Assert.fail(writer.toString());
+        Assertions.fail(writer.toString());
     }
 }

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/microprofile/test/client/exception/resource/ClientWebApplicationExceptionMicroProfileProxyResource.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/microprofile/test/client/exception/resource/ClientWebApplicationExceptionMicroProfileProxyResource.java
@@ -31,7 +31,7 @@ import org.jboss.resteasy.client.exception.ResteasyWebApplicationException;
 import org.jboss.resteasy.client.exception.WebApplicationExceptionWrapper;
 import org.jboss.resteasy.microprofile.test.client.exception.ClientWebApplicationExceptionConstants;
 import org.jboss.resteasy.plugins.server.servlet.ResteasyContextParameters;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 
 @Path("test")
 public class ClientWebApplicationExceptionMicroProfileProxyResource {
@@ -131,11 +131,11 @@ public class ClientWebApplicationExceptionMicroProfileProxyResource {
             throw new Exception("didn't expect ResteasyWebApplicationException", e);
         } catch (WebApplicationException e) {
             Response response = e.getResponse();
-            Assert.assertEquals(ClientWebApplicationExceptionConstants.oldExceptions[i].getResponse()
+            Assertions.assertEquals(ClientWebApplicationExceptionConstants.oldExceptions[i].getResponse()
                     .getStatus(), response.getStatus());
-            Assert.assertEquals(ClientWebApplicationExceptionConstants.oldExceptions[i].getResponse()
+            Assertions.assertEquals(ClientWebApplicationExceptionConstants.oldExceptions[i].getResponse()
                     .getHeaderString("foo"), response.getHeaderString("foo"));
-            Assert.assertEquals(ClientWebApplicationExceptionConstants.oldExceptions[i].getResponse()
+            Assertions.assertEquals(ClientWebApplicationExceptionConstants.oldExceptions[i].getResponse()
                     .getEntity(), response.readEntity(String.class));
             throw e;
         } catch (Exception e) {
@@ -163,11 +163,11 @@ public class ClientWebApplicationExceptionMicroProfileProxyResource {
             throw new Exception("didn't expect ResteasyWebApplicationException", e);
         } catch (WebApplicationException e) {
             Response response = e.getResponse();
-            Assert.assertNotNull(response);
-            Assert.assertEquals(ClientWebApplicationExceptionConstants.newExceptions[i].getResponse()
+            Assertions.assertNotNull(response);
+            Assertions.assertEquals(ClientWebApplicationExceptionConstants.newExceptions[i].getResponse()
                     .getStatus(), response.getStatus());
-            Assert.assertNull(response.getHeaderString("foo"));
-            Assert.assertTrue(response.readEntity(String.class).length() == 0);
+            Assertions.assertNull(response.getHeaderString("foo"));
+            Assertions.assertTrue(response.readEntity(String.class).length() == 0);
             throw e;
         } catch (Exception e) {
             throw new Exception("expected WebApplicationException, not " + e.getClass());
@@ -196,19 +196,19 @@ public class ClientWebApplicationExceptionMicroProfileProxyResource {
             throw new Exception("didn't expect ResteasyWebApplicationException", e);
         } catch (WebApplicationException e) {
             Response sanitizedResponse = e.getResponse();
-            Assert.assertEquals(ClientWebApplicationExceptionConstants.oldExceptions[i].getResponse()
+            Assertions.assertEquals(ClientWebApplicationExceptionConstants.oldExceptions[i].getResponse()
                     .getStatus(), sanitizedResponse.getStatus());
-            Assert.assertNull(sanitizedResponse.getHeaderString("foo"));
-            Assert.assertFalse(sanitizedResponse.hasEntity());
+            Assertions.assertNull(sanitizedResponse.getHeaderString("foo"));
+            Assertions.assertFalse(sanitizedResponse.hasEntity());
             Response originalResponse = WebApplicationExceptionWrapper.unwrap(e).getResponse();
-            Assert.assertNotNull(originalResponse);
-            Assert.assertEquals(ClientWebApplicationExceptionConstants.oldExceptions[i].getResponse()
+            Assertions.assertNotNull(originalResponse);
+            Assertions.assertEquals(ClientWebApplicationExceptionConstants.oldExceptions[i].getResponse()
                     .getStatus(), originalResponse.getStatus());
-            Assert.assertEquals(ClientWebApplicationExceptionConstants.oldExceptions[i].getResponse()
+            Assertions.assertEquals(ClientWebApplicationExceptionConstants.oldExceptions[i].getResponse()
                     .getHeaderString("foo"), originalResponse.getHeaderString("foo"));
-            Assert.assertEquals(ClientWebApplicationExceptionConstants.oldExceptions[i].getResponse()
+            Assertions.assertEquals(ClientWebApplicationExceptionConstants.oldExceptions[i].getResponse()
                     .getEntity(), originalResponse.readEntity(String.class));
-            Assert.assertEquals(ClientWebApplicationExceptionConstants.newExceptionMap.get(originalResponse.getStatus()), e
+            Assertions.assertEquals(ClientWebApplicationExceptionConstants.newExceptionMap.get(originalResponse.getStatus()), e
                     .getClass());
             throw e;
         } catch (Exception e) {
@@ -238,18 +238,18 @@ public class ClientWebApplicationExceptionMicroProfileProxyResource {
             throw new Exception("didn't expect ResteasyWebApplicationException");
         } catch (WebApplicationException e) {
             Response sanitizedResponse = e.getResponse();
-            Assert.assertEquals(ClientWebApplicationExceptionConstants.newExceptions[i].getResponse()
+            Assertions.assertEquals(ClientWebApplicationExceptionConstants.newExceptions[i].getResponse()
                     .getStatus(), sanitizedResponse.getStatus());
-            Assert.assertNull(sanitizedResponse.getHeaderString("foo"));
-            Assert.assertFalse(sanitizedResponse.hasEntity());
+            Assertions.assertNull(sanitizedResponse.getHeaderString("foo"));
+            Assertions.assertFalse(sanitizedResponse.hasEntity());
             Response originalResponse = WebApplicationExceptionWrapper.unwrap(e).getResponse();
-            Assert.assertNotNull(originalResponse);
-            Assert.assertEquals(ClientWebApplicationExceptionConstants.newExceptions[i].getResponse()
+            Assertions.assertNotNull(originalResponse);
+            Assertions.assertEquals(ClientWebApplicationExceptionConstants.newExceptions[i].getResponse()
                     .getStatus(), originalResponse.getStatus());
-            Assert.assertEquals(ClientWebApplicationExceptionConstants.newExceptions[i].getResponse()
+            Assertions.assertEquals(ClientWebApplicationExceptionConstants.newExceptions[i].getResponse()
                     .getHeaderString("foo"), originalResponse.getHeaderString("foo"));
-            Assert.assertTrue(originalResponse.readEntity(String.class).isEmpty());
-            Assert.assertEquals(ClientWebApplicationExceptionConstants.newExceptionMap.get(originalResponse.getStatus()), e
+            Assertions.assertTrue(originalResponse.readEntity(String.class).isEmpty());
+            Assertions.assertEquals(ClientWebApplicationExceptionConstants.newExceptionMap.get(originalResponse.getStatus()), e
                     .getClass());
             throw e;
         } catch (Exception e) {

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/microprofile/test/client/integration/ContainerRestClientProxyTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/microprofile/test/client/integration/ContainerRestClientProxyTest.java
@@ -42,19 +42,19 @@ import jakarta.ws.rs.Path;
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
 import org.eclipse.microprofile.rest.client.inject.RestClient;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.resteasy.microprofile.test.util.TestEnvironment;
 import org.jboss.resteasy.utils.PermissionUtil;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
  */
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class ContainerRestClientProxyTest {
 
     @Deployment
@@ -84,17 +84,17 @@ public class ContainerRestClientProxyTest {
 
     @Test
     public void checkQualifiedClient() {
-        Assert.assertNotNull("Cliented injected with qualifier @RestClient should not be null", qualifiedClient);
+        Assertions.assertNotNull(qualifiedClient, "Cliented injected with qualifier @RestClient should not be null");
     }
 
     @Test
     public void intercepted() {
-        Assert.assertNotNull(client);
-        Assert.assertFalse(ClientInterceptor.invoked);
-        Assert.assertFalse(ClientMethodInterceptor.invoked);
-        Assert.assertEquals("test", client.get());
-        Assert.assertTrue(ClientInterceptor.invoked);
-        Assert.assertTrue(ClientMethodInterceptor.invoked);
+        Assertions.assertNotNull(client);
+        Assertions.assertFalse(ClientInterceptor.invoked);
+        Assertions.assertFalse(ClientMethodInterceptor.invoked);
+        Assertions.assertEquals("test", client.get());
+        Assertions.assertTrue(ClientInterceptor.invoked);
+        Assertions.assertTrue(ClientMethodInterceptor.invoked);
     }
 
     @RegisterRestClient

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/microprofile/test/client/integration/ExceptionMapperReturnsNullTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/microprofile/test/client/integration/ExceptionMapperReturnsNullTest.java
@@ -26,16 +26,16 @@ import jakarta.ws.rs.WebApplicationException;
 import org.eclipse.microprofile.rest.client.RestClientBuilder;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.resteasy.microprofile.test.client.integration.resource.HealthCheckData;
 import org.jboss.resteasy.microprofile.test.client.integration.resource.HealthService;
 import org.jboss.resteasy.microprofile.test.client.integration.resource.Ignore404ExceptionMapper;
 import org.jboss.resteasy.microprofile.test.util.TestEnvironment;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * @tpSubChapter MicroProfile rest client
@@ -47,7 +47,7 @@ import org.junit.runner.RunWith;
  *                    behavior for this scenario and when the default ResponseExceptionMapper is present.
  * @tpSince RESTEasy 4.7.0
  */
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 @RunAsClient
 public class ExceptionMapperReturnsNullTest {
 
@@ -67,16 +67,20 @@ public class ExceptionMapperReturnsNullTest {
                 .register(new Ignore404ExceptionMapper())
                 .build(HealthService.class)
                 .getHealthData();
-        Assert.assertNull(data);
+        Assertions.assertNull(data);
     }
 
-    @Test(expected = WebApplicationException.class)
+    @Test
     public void testDefaultExceptionMapper() throws Exception {
         HealthService healthServiceClient = RestClientBuilder.newBuilder()
                 .baseUri(TestEnvironment.generateUri(url, "test-app"))
                 .register(new Ignore404ExceptionMapper())
                 .build(HealthService.class);
 
-        healthServiceClient.getHealthData();
+        try {
+            healthServiceClient.getHealthData();
+        } catch (WebApplicationException e) {
+            // this is the expected result
+        }
     }
 }

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/microprofile/test/client/integration/FollowRedirectMPConfigPropertyTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/microprofile/test/client/integration/FollowRedirectMPConfigPropertyTest.java
@@ -28,16 +28,16 @@ import jakarta.ws.rs.core.Response;
 import org.eclipse.microprofile.rest.client.RestClientBuilder;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.resteasy.microprofile.client.RestClientBuilderImpl;
 import org.jboss.resteasy.microprofile.test.client.integration.resource.FollowRedirectsService;
 import org.jboss.resteasy.microprofile.test.client.integration.resource.FollowRedirectsServiceIntf;
 import org.jboss.resteasy.microprofile.test.util.TestEnvironment;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * @tpSubChapter MicroProfile rest client
@@ -45,7 +45,7 @@ import org.junit.runner.RunWith;
  * @tpTestCaseDetails Show using microprofile-config property, "/mp-rest/followRedirects" works.
  * @tpSince RESTEasy 4.6.0
  */
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 @RunAsClient
 public class FollowRedirectMPConfigPropertyTest {
     private static final String MP_REST_FOLLOWREDIRECT = "/mp-rest/followRedirects";
@@ -106,8 +106,8 @@ public class FollowRedirectMPConfigPropertyTest {
             final Response.Status expectedStatus,
             final String expectedText) {
         try (Response response = followRedirectsServiceIntf.redirectPing()) {
-            Assert.assertEquals(expectedStatus.getStatusCode(), response.getStatus());
-            Assert.assertEquals(expectedText, response.readEntity(String.class));
+            Assertions.assertEquals(expectedStatus.getStatusCode(), response.getStatus());
+            Assertions.assertEquals(expectedText, response.readEntity(String.class));
         }
     }
 }

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/microprofile/test/client/integration/FollowRedirectsTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/microprofile/test/client/integration/FollowRedirectsTest.java
@@ -27,17 +27,17 @@ import org.eclipse.microprofile.rest.client.RestClientBuilder;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.OperateOnDeployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.resteasy.microprofile.test.client.integration.resource.FollowRedirectsResource;
 import org.jboss.resteasy.microprofile.test.client.integration.resource.FollowRedirectsService;
 import org.jboss.resteasy.microprofile.test.client.integration.resource.FollowRedirectsServiceIntf;
 import org.jboss.resteasy.microprofile.test.util.TestEnvironment;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * @tpSubChapter MicroProfile rest client
@@ -45,7 +45,7 @@ import org.junit.runner.RunWith;
  * @tpTestCaseDetails Show followsRedirects flag works.
  * @tpSince RESTEasy 4.6.0
  */
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 @RunAsClient
 public class FollowRedirectsTest {
     private static final String WAR_SERVICE = "followRedirects_service";
@@ -69,7 +69,7 @@ public class FollowRedirectsTest {
     @OperateOnDeployment(WAR_SERVICE)
     private URL url;
 
-    @Before
+    @BeforeEach
     public void before() throws Exception {
         RestClientBuilder builder = RestClientBuilder.newBuilder();
         followRedirectsServiceIntf = builder
@@ -91,7 +91,7 @@ public class FollowRedirectsTest {
                 .build(FollowRedirectsServiceIntf.class);
 
         Response response = result.tmpRedirect(THE_PATRON, WAR_CLIENT);
-        Assert.assertEquals(307, response.getStatus());
+        Assertions.assertEquals(307, response.getStatus());
         response.close();
     }
 
@@ -101,8 +101,8 @@ public class FollowRedirectsTest {
     @Test
     public void followTemporaryRedirect() {
         Response response = followRedirectsServiceIntf.tmpRedirect(THE_PATRON, WAR_CLIENT);
-        Assert.assertEquals(200, response.getStatus());
-        Assert.assertEquals("OK", response.readEntity(String.class));
+        Assertions.assertEquals(200, response.getStatus());
+        Assertions.assertEquals("OK", response.readEntity(String.class));
         response.close();
     }
 
@@ -112,8 +112,8 @@ public class FollowRedirectsTest {
     @Test
     public void postRedirect() {
         Response response = followRedirectsServiceIntf.postRedirect(WAR_CLIENT);
-        Assert.assertEquals(200, response.getStatus());
-        Assert.assertEquals("OK", response.readEntity(String.class));
+        Assertions.assertEquals(200, response.getStatus());
+        Assertions.assertEquals("OK", response.readEntity(String.class));
         response.close();
     }
 
@@ -123,8 +123,8 @@ public class FollowRedirectsTest {
     @Test
     public void movedPermanently() {
         Response response = followRedirectsServiceIntf.movedPermanently(THE_PATRON, WAR_CLIENT);
-        Assert.assertEquals(200, response.getStatus());
-        Assert.assertEquals("ok - direct response",
+        Assertions.assertEquals(200, response.getStatus());
+        Assertions.assertEquals("ok - direct response",
                 response.readEntity(String.class));
         response.close();
     }
@@ -135,8 +135,8 @@ public class FollowRedirectsTest {
     @Test
     public void found() {
         Response response = followRedirectsServiceIntf.found(THE_PATRON, WAR_CLIENT);
-        Assert.assertEquals(200, response.getStatus());
-        Assert.assertEquals("ok - direct response",
+        Assertions.assertEquals(200, response.getStatus());
+        Assertions.assertEquals("ok - direct response",
                 response.readEntity(String.class));
         response.close();
     }

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/microprofile/test/client/integration/JsonBindingMPTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/microprofile/test/client/integration/JsonBindingMPTest.java
@@ -24,16 +24,16 @@ import java.net.URL;
 import org.eclipse.microprofile.rest.client.RestClientBuilder;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.resteasy.microprofile.test.client.integration.resource.Dog;
 import org.jboss.resteasy.microprofile.test.client.integration.resource.JsonBindingMPService;
 import org.jboss.resteasy.microprofile.test.client.integration.resource.JsonBindingMPServiceIntf;
 import org.jboss.resteasy.microprofile.test.util.TestEnvironment;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * @tpSubChapter MicroProfile rest client
@@ -41,7 +41,7 @@ import org.junit.runner.RunWith;
  * @tpTestCaseDetails Show JSON-Binding is supported.
  * @tpSince RESTEasy 4.6.0
  */
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 @RunAsClient
 public class JsonBindingMPTest {
 
@@ -64,10 +64,10 @@ public class JsonBindingMPTest {
         try {
             Dog dog = new Dog("Rex", "german shepherd");
             Dog response = jsonBindingMPServiceIntf.getDog(dog);
-            Assert.assertEquals("Jethro", response.getName());
-            Assert.assertEquals("stafford", response.getSort());
+            Assertions.assertEquals("Jethro", response.getName());
+            Assertions.assertEquals("stafford", response.getSort());
         } catch (Exception e) {
-            Assert.fail("Exception thrown: " + e);
+            Assertions.fail("Exception thrown: " + e);
         }
     }
 }

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/microprofile/test/client/integration/JsonpMPTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/microprofile/test/client/integration/JsonpMPTest.java
@@ -31,16 +31,16 @@ import jakarta.json.JsonStructure;
 import org.eclipse.microprofile.rest.client.RestClientBuilder;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.resteasy.microprofile.test.client.integration.resource.JsonpMPService;
 import org.jboss.resteasy.microprofile.test.client.integration.resource.JsonpMPServiceIntf;
 import org.jboss.resteasy.microprofile.test.util.TestEnvironment;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * @tpSubChapter MicroProfile rest client
@@ -48,7 +48,7 @@ import org.junit.runner.RunWith;
  * @tpTestCaseDetails Show JSON-P is supported.
  * @tpSince RESTEasy 4.6.0
  */
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 @RunAsClient
 public class JsonpMPTest {
 
@@ -63,7 +63,7 @@ public class JsonpMPTest {
     @ArquillianResource
     private URL url;
 
-    @Before
+    @BeforeEach
     public void before() throws Exception {
         RestClientBuilder builder = RestClientBuilder.newBuilder();
         jsonpMPServiceIntf = builder
@@ -80,14 +80,14 @@ public class JsonpMPTest {
                 .build();
 
         JsonObject response = jsonpMPServiceIntf.object(obj);
-        Assert.assertTrue("JsonObject from the response doesn't contain field 'name'",
-                response.containsKey("name"));
-        Assert.assertEquals("JsonObject from the response doesn't contain correct value for the field 'name'",
-                response.getJsonString("name").getString(), "Bill");
-        Assert.assertTrue("JsonObject from the response doesn't contain field 'id'",
-                response.containsKey("id"));
-        Assert.assertEquals("JsonObject from the response doesn't contain correct value for the field 'id'",
-                response.getJsonNumber("id").longValue(), 10001);
+        Assertions.assertTrue(response.containsKey("name"),
+                "JsonObject from the response doesn't contain field 'name'");
+        Assertions.assertEquals(response.getJsonString("name").getString(), "Bill",
+                "JsonObject from the response doesn't contain correct value for the field 'name'");
+        Assertions.assertTrue(response.containsKey("id"),
+                "JsonObject from the response doesn't contain field 'id'");
+        Assertions.assertEquals(response.getJsonNumber("id").longValue(), 10001,
+                "JsonObject from the response doesn't contain correct value for the field 'id'");
     }
 
     @Test
@@ -95,18 +95,18 @@ public class JsonpMPTest {
         JsonStructure structure = (JsonStructure) Json.createObjectBuilder().add("name", "Bill").build();
         JsonStructure response = jsonpMPServiceIntf.object(structure);
         JsonObject obj = (JsonObject) response;
-        Assert.assertTrue("JsonObject from the response doesn't contain field 'name'",
-                obj.containsKey("name"));
-        Assert.assertEquals("JsonObject from the response doesn't contain correct value for the field 'name'",
-                obj.getJsonString("name").getString(), "Bill");
+        Assertions.assertTrue(obj.containsKey("name"),
+                "JsonObject from the response doesn't contain field 'name'");
+        Assertions.assertEquals(obj.getJsonString("name").getString(), "Bill",
+                "JsonObject from the response doesn't contain correct value for the field 'name'");
     }
 
     @Test
     public void testJsonNumber() {
         JsonNumber jsonNumber = Json.createValue(100);
         JsonNumber response = jsonpMPServiceIntf.testNumber(jsonNumber);
-        Assert.assertTrue("JsonNumber object with 200 value is expected",
-                response.intValue() == 200);
+        Assertions.assertTrue(response.intValue() == 200,
+                "JsonNumber object with 200 value is expected");
     }
 
     @Test
@@ -117,18 +117,18 @@ public class JsonpMPTest {
                 .build();
 
         JsonArray response = jsonpMPServiceIntf.array(array);
-        Assert.assertEquals("JsonArray from the response doesn't contain two elements as it should",
-                2, response.size());
+        Assertions.assertEquals(2, response.size(),
+                "JsonArray from the response doesn't contain two elements as it should");
         JsonObject obj = response.getJsonObject(0);
-        Assert.assertTrue("JsonObject[0] from the response doesn't contain field 'name'",
-                obj.containsKey("name"));
-        Assert.assertEquals("JsonObject[0] from the response doesn't contain correct value for the field 'name'",
-                obj.getJsonString("name").getString(), "Bill");
+        Assertions.assertTrue(obj.containsKey("name"),
+                "JsonObject[0] from the response doesn't contain field 'name'");
+        Assertions.assertEquals(obj.getJsonString("name").getString(), "Bill",
+                "JsonObject[0] from the response doesn't contain correct value for the field 'name'");
         obj = response.getJsonObject(1);
-        Assert.assertTrue("JsonObject[1] from the response doesn't contain field 'name'",
-                obj.containsKey("name"));
-        Assert.assertEquals("JsonObject[1] from the response doesn't contain correct value for the field 'name'",
-                obj.getJsonString("name").getString(), "Monica");
+        Assertions.assertTrue(obj.containsKey("name"),
+                "JsonObject[1] from the response doesn't contain field 'name'");
+        Assertions.assertEquals(obj.getJsonString("name").getString(), "Monica",
+                "JsonObject[1] from the response doesn't contain correct value for the field 'name'");
     }
 
     @Test
@@ -137,7 +137,7 @@ public class JsonpMPTest {
         JsonString jsonString = Json.createValue("Resteasy");
         JsonString response = jsonpMPServiceIntf.testString(jsonString);
 
-        Assert.assertTrue("JsonString object with Hello Resteasy value is expected",
-                response.getString().equals("Hello Resteasy"));
+        Assertions.assertTrue(response.getString().equals("Hello Resteasy"),
+                "JsonString object with Hello Resteasy value is expected");
     }
 }

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/microprofile/test/client/integration/MPClientCollectionTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/microprofile/test/client/integration/MPClientCollectionTest.java
@@ -32,7 +32,7 @@ import jakarta.ws.rs.core.Response;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.OperateOnDeployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.logging.Logger;
 import org.jboss.resteasy.microprofile.test.client.integration.resource.MPCollectionActivator;
@@ -41,11 +41,11 @@ import org.jboss.resteasy.microprofile.test.client.integration.resource.MPCollec
 import org.jboss.resteasy.microprofile.test.client.integration.resource.MPCollectionServiceIntf;
 import org.jboss.resteasy.microprofile.test.util.TestEnvironment;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * @tpSubChapter MicroProfile Config
@@ -54,7 +54,7 @@ import org.junit.runner.RunWith;
  *                    Show configuration required for a GenericType return type.
  * @tpSince RESTEasy 4.6.0
  */
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 @RunAsClient
 public class MPClientCollectionTest {
     protected static final Logger LOG = Logger.getLogger(MPCollectionTest.class.getName());
@@ -86,12 +86,12 @@ public class MPClientCollectionTest {
     @OperateOnDeployment(WAR_CLIENT)
     private URL clientUrl;
 
-    @BeforeClass
+    @BeforeAll
     public static void before() throws Exception {
         client = ClientBuilder.newClient();
     }
 
-    @AfterClass
+    @AfterAll
     public static void after() throws Exception {
         client.close();
     }
@@ -102,8 +102,8 @@ public class MPClientCollectionTest {
         // If this test fails the other tests will not pass
         Response response = client.target(
                 TestEnvironment.generateUri(warUrl, "/theService/ping")).request().get();
-        Assert.assertEquals(200, response.getStatus());
-        Assert.assertEquals("pong", response.readEntity(String.class));
+        Assertions.assertEquals(200, response.getStatus());
+        Assertions.assertEquals("pong", response.readEntity(String.class));
     }
 
     @Test
@@ -113,8 +113,8 @@ public class MPClientCollectionTest {
         // Test endpoint with simple (String) return type
         Response response = client.target(
                 TestEnvironment.generateUri(clientUrl, "/theService/thePatron/checking")).request().get();
-        Assert.assertEquals(200, response.getStatus());
-        Assert.assertEquals("pong thePatron", response.readEntity(String.class));
+        Assertions.assertEquals(200, response.getStatus());
+        Assertions.assertEquals("pong thePatron", response.readEntity(String.class));
     }
 
     @Test
@@ -123,10 +123,10 @@ public class MPClientCollectionTest {
         // Test endpoint with GenericType return type
         Response response = client.target(
                 TestEnvironment.generateUri(clientUrl, "/theService/thePatron/got")).request().get();
-        Assert.assertEquals(200, response.getStatus());
+        Assertions.assertEquals(200, response.getStatus());
         List<String> l = response.readEntity(new GenericType<List<String>>() {
         });
-        Assert.assertEquals(4, l.size());
-        Assert.assertEquals("thePatron", l.get(3));
+        Assertions.assertEquals(4, l.size());
+        Assertions.assertEquals("thePatron", l.get(3));
     }
 }

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/microprofile/test/client/integration/MPCollectionTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/microprofile/test/client/integration/MPCollectionTest.java
@@ -25,16 +25,16 @@ import java.util.List;
 import org.eclipse.microprofile.rest.client.RestClientBuilder;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.resteasy.microprofile.test.client.integration.resource.MPCollectionActivator;
 import org.jboss.resteasy.microprofile.test.client.integration.resource.MPCollectionService;
 import org.jboss.resteasy.microprofile.test.client.integration.resource.MPCollectionServiceIntf;
 import org.jboss.resteasy.microprofile.test.util.TestEnvironment;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * @tpSubChapter MicroProfile Config
@@ -42,7 +42,7 @@ import org.junit.runner.RunWith;
  * @tpTestCaseDetails Show how to get the proxy for the service.
  * @tpSince RESTEasy 4.6.0
  */
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 @RunAsClient
 public class MPCollectionTest {
 
@@ -62,6 +62,6 @@ public class MPCollectionTest {
         MPCollectionServiceIntf mpc = builder.baseUri(TestEnvironment.generateUri(url))
                 .build(MPCollectionServiceIntf.class);
         List<String> l = mpc.getList();
-        Assert.assertEquals(3, l.size());
+        Assertions.assertEquals(3, l.size());
     }
 }

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/microprofile/test/client/integration/QueryParamStyleMPConfigPropertyTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/microprofile/test/client/integration/QueryParamStyleMPConfigPropertyTest.java
@@ -26,16 +26,16 @@ import java.util.List;
 import org.eclipse.microprofile.rest.client.RestClientBuilder;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.resteasy.microprofile.test.client.integration.resource.QueryParamStyleService;
 import org.jboss.resteasy.microprofile.test.client.integration.resource.QueryParamStyleServiceIntf;
 import org.jboss.resteasy.microprofile.test.util.TestEnvironment;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * @tpSubChapter MicroProfile rest client
@@ -43,7 +43,7 @@ import org.junit.runner.RunWith;
  * @tpTestCaseDetails Show using microprofile-config property, "/mp-rest/queryParamStyle" works.
  * @tpSince RESTEasy 4.6.0
  */
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 @RunAsClient
 public class QueryParamStyleMPConfigPropertyTest {
 
@@ -59,7 +59,7 @@ public class QueryParamStyleMPConfigPropertyTest {
     @ArquillianResource
     private URL url;
 
-    @Before
+    @BeforeEach
     public void before() throws Exception {
         builder = RestClientBuilder.newBuilder();
         builder.baseUri(TestEnvironment.generateUri(url, "test-app"));
@@ -79,8 +79,8 @@ public class QueryParamStyleMPConfigPropertyTest {
                 .build(QueryParamStyleServiceIntf.class);
 
         List<String> l = serviceIntf.getList(argList);
-        Assert.assertEquals(2, l.size());
-        Assert.assertEquals("client call,hello,three", l.get(0));
+        Assertions.assertEquals(2, l.size());
+        Assertions.assertEquals("client call,hello,three", l.get(0));
         System.clearProperty(key);
     }
 
@@ -93,8 +93,8 @@ public class QueryParamStyleMPConfigPropertyTest {
                 .build(QueryParamStyleServiceIntf.class);
 
         List<String> l = serviceIntf.getList(argList);
-        Assert.assertEquals(1, l.size());
-        Assert.assertEquals("theService reached", l.get(0));
+        Assertions.assertEquals(1, l.size());
+        Assertions.assertEquals("theService reached", l.get(0));
         System.clearProperty(key);
     }
 }

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/microprofile/test/client/integration/QueryParamStyleTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/microprofile/test/client/integration/QueryParamStyleTest.java
@@ -27,16 +27,16 @@ import org.eclipse.microprofile.rest.client.RestClientBuilder;
 import org.eclipse.microprofile.rest.client.ext.QueryParamStyle;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.resteasy.microprofile.test.client.integration.resource.QueryParamStyleService;
 import org.jboss.resteasy.microprofile.test.client.integration.resource.QueryParamStyleServiceIntf;
 import org.jboss.resteasy.microprofile.test.util.TestEnvironment;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * @tpSubChapter MicroProfile rest client
@@ -44,7 +44,7 @@ import org.junit.runner.RunWith;
  * @tpTestCaseDetails Show QueryParamStyle working.
  * @tpSince RESTEasy 4.6.0
  */
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 @RunAsClient
 public class QueryParamStyleTest {
 
@@ -60,7 +60,7 @@ public class QueryParamStyleTest {
     @ArquillianResource
     private URL url;
 
-    @Before
+    @BeforeEach
     public void before() throws Exception {
         builder = RestClientBuilder.newBuilder();
         builder.baseUri(TestEnvironment.generateUri(url, "test-app"));
@@ -81,8 +81,8 @@ public class QueryParamStyleTest {
                 .build(QueryParamStyleServiceIntf.class);
         List<String> l = serviceIntf.getList(argList);
 
-        Assert.assertEquals(4, l.size());
-        Assert.assertEquals("theService reached", l.get(3));
+        Assertions.assertEquals(4, l.size());
+        Assertions.assertEquals("theService reached", l.get(3));
     }
 
     /*
@@ -96,8 +96,8 @@ public class QueryParamStyleTest {
                 .build(QueryParamStyleServiceIntf.class);
 
         List<String> l = serviceIntf.getList(argList);
-        Assert.assertEquals(4, l.size());
-        Assert.assertEquals("theService reached", l.get(3));
+        Assertions.assertEquals(4, l.size());
+        Assertions.assertEquals("theService reached", l.get(3));
     }
 
     /*
@@ -111,8 +111,8 @@ public class QueryParamStyleTest {
                 .build(QueryParamStyleServiceIntf.class);
 
         List<String> l = serviceIntf.getList(argList);
-        Assert.assertEquals(2, l.size());
-        Assert.assertEquals("client call,hello,three", l.get(0));
+        Assertions.assertEquals(2, l.size());
+        Assertions.assertEquals("client call,hello,three", l.get(0));
     }
 
     /*
@@ -126,7 +126,7 @@ public class QueryParamStyleTest {
                 .build(QueryParamStyleServiceIntf.class);
 
         List<String> l = serviceIntf.getList(argList);
-        Assert.assertEquals(1, l.size());
-        Assert.assertEquals("theService reached", l.get(0));
+        Assertions.assertEquals(1, l.size());
+        Assertions.assertEquals("theService reached", l.get(0));
     }
 }

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/microprofile/test/client/integration/RestClientContextProviderTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/microprofile/test/client/integration/RestClientContextProviderTest.java
@@ -32,7 +32,7 @@ import jakarta.ws.rs.core.Response;
 import org.eclipse.microprofile.rest.client.RestClientBuilder;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.resteasy.microprofile.test.client.integration.resource.TestAsyncClient;
 import org.jboss.resteasy.microprofile.test.client.integration.resource.TestAsyncFilter;
@@ -41,14 +41,14 @@ import org.jboss.resteasy.microprofile.test.client.integration.resource.TestAsyn
 import org.jboss.resteasy.microprofile.test.util.TestEnvironment;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
  */
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 @RunAsClient
 public class RestClientContextProviderTest {
 
@@ -85,17 +85,17 @@ public class RestClientContextProviderTest {
                 .executorService(testExecutorService)
                 .build(TestAsyncClient.class);
         final Response response = client.get().toCompletableFuture().get(5, TimeUnit.SECONDS);
-        Assert.assertEquals(Response.Status.OK, response.getStatusInfo());
-        Assert.assertEquals(String.format("{prepareContext=%s, applyContext=%s}", currentThreadName, asyncThreadName),
+        Assertions.assertEquals(Response.Status.OK, response.getStatusInfo());
+        Assertions.assertEquals(String.format("{prepareContext=%s, applyContext=%s}", currentThreadName, asyncThreadName),
                 response.getHeaderString("test1-state"));
 
         // Wait until the context has been removed
-        Assert.assertTrue("Timeout waiting for remove to be invoked.", removed.await(5, TimeUnit.SECONDS));
+        Assertions.assertTrue(removed.await(5, TimeUnit.SECONDS), "Timeout waiting for remove to be invoked.");
         final Map<String, String> data = TestAsyncInvocationInterceptorFactory.localState.get();
-        Assert.assertEquals("Expected 3 entries found: " + data, 3, data.size());
-        Assert.assertEquals(currentThreadName, data.get("prepareContext"));
-        Assert.assertEquals(asyncThreadName, data.get("applyContext"));
-        Assert.assertEquals(asyncThreadName, data.get("removeContext"));
+        Assertions.assertEquals(3, data.size(), "Expected 3 entries found: " + data);
+        Assertions.assertEquals(currentThreadName, data.get("prepareContext"));
+        Assertions.assertEquals(asyncThreadName, data.get("applyContext"));
+        Assertions.assertEquals(asyncThreadName, data.get("removeContext"));
 
         testExecutorService.shutdownNow();
     }

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/microprofile/test/client/integration/RestClientNonProxyHostsPatternTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/microprofile/test/client/integration/RestClientNonProxyHostsPatternTest.java
@@ -19,7 +19,7 @@
 
 package org.jboss.resteasy.microprofile.test.client.integration;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.net.URL;
 import java.util.HashMap;
@@ -29,12 +29,12 @@ import org.eclipse.microprofile.rest.client.RestClientBuilder;
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.resteasy.microprofile.test.util.TestEnvironment;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * MicroProfile rest client
@@ -43,7 +43,7 @@ import org.junit.runner.RunWith;
  * regex.PatternSyntaxException while trying to build a rest client
  * https://github.com/resteasy/resteasy-microprofile/issues/10
  */
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 @RunAsClient
 public class RestClientNonProxyHostsPatternTest {
 

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/microprofile/test/client/integration/RestClientProviderPriorityTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/microprofile/test/client/integration/RestClientProviderPriorityTest.java
@@ -19,7 +19,7 @@
 
 package org.jboss.resteasy.microprofile.test.client.integration;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.IOException;
 import java.net.URL;
@@ -38,15 +38,15 @@ import org.eclipse.microprofile.rest.client.annotation.RegisterProvider;
 import org.eclipse.microprofile.rest.client.annotation.RegisterProviders;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.resteasy.microprofile.test.util.TestEnvironment;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 @RunAsClient
 public class RestClientProviderPriorityTest {
     @ArquillianResource

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/microprofile/test/client/integration/RestClientProxyRedeployTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/microprofile/test/client/integration/RestClientProxyRedeployTest.java
@@ -29,18 +29,18 @@ import jakarta.ws.rs.core.Response;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.OperateOnDeployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.resteasy.microprofile.test.client.integration.resource.RestClientProxyRedeployRemoteService;
 import org.jboss.resteasy.microprofile.test.client.integration.resource.RestClientProxyRedeployResource;
 import org.jboss.resteasy.microprofile.test.util.TestEnvironment;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 @RunAsClient
 public class RestClientProxyRedeployTest {
     @Deployment(name = "deployment1", order = 1)
@@ -69,9 +69,9 @@ public class RestClientProxyRedeployTest {
     public void testGet1() throws Exception {
         Client client = ClientBuilder.newClient();
         Response response = client.target(TestEnvironment.generateUri(url1, "/test-app/test/1")).request().get();
-        Assert.assertEquals(200, response.getStatus());
+        Assertions.assertEquals(200, response.getStatus());
         String entity = response.readEntity(String.class);
-        Assert.assertEquals("OK", entity);
+        Assertions.assertEquals("OK", entity);
         client.close();
     }
 
@@ -79,9 +79,9 @@ public class RestClientProxyRedeployTest {
     public void testGet2() throws Exception {
         Client client = ClientBuilder.newClient();
         Response response = client.target(TestEnvironment.generateUri(url2, "/test-app/test/1")).request().get();
-        Assert.assertEquals(200, response.getStatus());
+        Assertions.assertEquals(200, response.getStatus());
         String entity = response.readEntity(String.class);
-        Assert.assertEquals("OK", entity);
+        Assertions.assertEquals("OK", entity);
         client.close();
     }
 }

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/microprofile/test/client/integration/RestClientProxyTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/microprofile/test/client/integration/RestClientProxyTest.java
@@ -19,11 +19,11 @@
 
 package org.jboss.resteasy.microprofile.test.client.integration;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.IOException;
 import java.lang.annotation.Annotation;
@@ -47,7 +47,7 @@ import jakarta.ws.rs.ext.Provider;
 import org.eclipse.microprofile.rest.client.RestClientBuilder;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.resteasy.client.jaxrs.engines.vertx.VertxClientHttpEngine;
 import org.jboss.resteasy.microprofile.client.BuilderResolver;
@@ -55,22 +55,21 @@ import org.jboss.resteasy.microprofile.test.client.integration.resource.HeaderPr
 import org.jboss.resteasy.microprofile.test.client.integration.resource.HelloClient;
 import org.jboss.resteasy.microprofile.test.client.integration.resource.HelloResource;
 import org.jboss.resteasy.microprofile.test.client.integration.resource.NgHTTP2;
-import org.jboss.resteasy.microprofile.test.util.IgnoreOnCi;
 import org.jboss.resteasy.microprofile.test.util.TestEnvironment;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import io.vertx.core.Vertx;
 import io.vertx.core.http.HttpClientOptions;
 import io.vertx.core.http.HttpVersion;
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 @RunAsClient
-@Category(IgnoreOnCi.class)
+@Tag("IgnoreOnCi.class")
 public class RestClientProxyTest {
 
     public static final String EMOJIS = "\uD83D\uDE00\uD83D\uDE00\uD83D\uDE00\uD83D\uDE00\uD83D\uDE00\uD83D\uDE00\uD83D\uDE00\uD83D\uDE00";
@@ -155,7 +154,7 @@ public class RestClientProxyTest {
             return s;
         });
         boolean waitResult = latch.await(30, TimeUnit.SECONDS);
-        Assert.assertTrue("Waiting for event to be delivered has timed out.", waitResult);
+        Assertions.assertTrue(waitResult, "Waiting for event to be delivered has timed out.");
         assertEquals("foo", value.get());
     }
 
@@ -207,7 +206,7 @@ public class RestClientProxyTest {
             latch.countDown();
         });
         boolean waitResult = latch.await(30, TimeUnit.SECONDS);
-        Assert.assertTrue("Waiting for event to be delivered has timed out.", waitResult);
+        Assertions.assertTrue(waitResult, "Waiting for event to be delivered has timed out.");
         assertTrue(value.get() instanceof WebApplicationException);
         assertEquals(Response.Status.NOT_FOUND.getStatusCode(), ((WebApplicationException) value.get()).getResponse()
                 .getStatus());
@@ -232,7 +231,7 @@ public class RestClientProxyTest {
             // via the message id.
             final String msg = e.getLocalizedMessage();
             final String msgId = "RESTEASY004690";
-            assertTrue(String.format("Expected message to start with %s: %s", msgId, msg), msg.startsWith(msgId));
+            assertTrue(msg.startsWith(msgId), String.format("Expected message to start with %s: %s", msgId, msg));
         }
     }
 
@@ -256,7 +255,7 @@ public class RestClientProxyTest {
             // via the message id.
             final String msg = e.getLocalizedMessage();
             final String msgId = "RESTEASY004690";
-            assertTrue(String.format("Expected message to start with %s: %s", msgId, msg), msg.startsWith(msgId));
+            assertTrue(msg.startsWith(msgId), String.format("Expected message to start with %s: %s", msgId, msg));
         }
     }
 

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/microprofile/test/client/integration/SsePublisherClientTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/microprofile/test/client/integration/SsePublisherClientTest.java
@@ -19,9 +19,9 @@
 
 package org.jboss.resteasy.microprofile.test.client.integration;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.net.URL;
 import java.util.HashSet;
@@ -32,23 +32,23 @@ import java.util.concurrent.TimeUnit;
 import org.eclipse.microprofile.rest.client.RestClientBuilder;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.resteasy.microprofile.client.BuilderResolver;
 import org.jboss.resteasy.microprofile.test.client.integration.resource.MPSseClient;
 import org.jboss.resteasy.microprofile.test.client.integration.resource.MPSseResource;
 import org.jboss.resteasy.microprofile.test.util.TestEnvironment;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 @RunAsClient
 public class SsePublisherClientTest {
     @ArquillianResource
@@ -60,12 +60,12 @@ public class SsePublisherClientTest {
                 .addClasses(MPSseResource.class);
     }
 
-    @Before
+    @BeforeEach
     public void setup() {
         System.setProperty("resteasy.microprofile.sseclient.buffersize", "5");
     }
 
-    @After
+    @AfterEach
     public void cleanup() {
         System.clearProperty("resteasy.microprofile.sseclient.buffersize");
     }
@@ -98,8 +98,8 @@ public class SsePublisherClientTest {
         //sent 12 items, expects these 10 values : msg0~msg4 and msg7~msg11
         assertEquals(10, eventStrings.size());
         //msg5 and msg6 are dropped
-        Assert.assertFalse("Expected [msg4, msg3, msg2, msg1, msg8, msg11, msg7, msg10, msg9, msg0], found " + eventStrings,
-                eventStrings.contains("msg5") || eventStrings.contains("msg6"));
+        Assertions.assertFalse(eventStrings.contains("msg5") || eventStrings.contains("msg6"),
+                "Expected [msg4, msg3, msg2, msg1, msg8, msg11, msg7, msg10, msg9, msg0], found " + eventStrings);
         assertNull(subscriber.throwable);
     }
 

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/microprofile/test/client/integration/resource/HeaderPropagator.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/microprofile/test/client/integration/resource/HeaderPropagator.java
@@ -26,13 +26,13 @@ import jakarta.ws.rs.core.MultivaluedMap;
 
 import org.eclipse.microprofile.rest.client.ext.ClientHeadersFactory;
 import org.jboss.resteasy.core.ResteasyContext;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 
 public class HeaderPropagator implements ClientHeadersFactory {
     @Override
     public MultivaluedMap<String, String> update(MultivaluedMap<String, String> containerRequestHeaders,
             MultivaluedMap<String, String> clientRequestHeaders) {
-        Assert.assertNull(ResteasyContext.getContextData(HttpHeaders.class));
+        Assertions.assertNull(ResteasyContext.getContextData(HttpHeaders.class));
         List<String> prop = containerRequestHeaders.get("X-Propagated");
         if (prop != null)
             clientRequestHeaders.addAll("X-Propagated", prop);

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/microprofile/test/client/integration/resource/HelloResource.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/microprofile/test/client/integration/resource/HelloResource.java
@@ -31,7 +31,7 @@ import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.QueryParam;
 
 import org.eclipse.microprofile.rest.client.inject.RestClient;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 
 @Path("/")
 public class HelloResource {
@@ -76,8 +76,8 @@ public class HelloResource {
     @Path("async-client-target")
     public CompletionStage<String> asyncClientTarget(@HeaderParam("X-Propagated") String propagatedHeader,
             @HeaderParam("X-Not-Propagated") String nonPropagatedHeader) {
-        Assert.assertNull(nonPropagatedHeader);
-        Assert.assertEquals("got-a-value", propagatedHeader);
+        Assertions.assertNull(nonPropagatedHeader);
+        Assertions.assertEquals("got-a-value", propagatedHeader);
         return CompletableFuture.completedFuture("OK");
     }
 
@@ -85,8 +85,8 @@ public class HelloResource {
     @Path("async-client")
     public CompletionStage<String> asyncClient(@HeaderParam("X-Propagated") String propagatedHeader,
             @HeaderParam("X-Not-Propagated") String nonPropagatedHeader) {
-        Assert.assertEquals("got-a-value", propagatedHeader);
-        Assert.assertEquals("got-a-value", nonPropagatedHeader);
+        Assertions.assertEquals("got-a-value", propagatedHeader);
+        Assertions.assertEquals("got-a-value", nonPropagatedHeader);
         return rest.asyncClientTarget();
     }
 
@@ -94,8 +94,8 @@ public class HelloResource {
     @Path("client-target")
     public String clientTarget(@HeaderParam("X-Propagated") String propagatedHeader,
             @HeaderParam("X-Not-Propagated") String nonPropagatedHeader) {
-        Assert.assertNull(nonPropagatedHeader);
-        Assert.assertEquals("got-a-value", propagatedHeader);
+        Assertions.assertNull(nonPropagatedHeader);
+        Assertions.assertEquals("got-a-value", propagatedHeader);
         return "OK";
     }
 
@@ -103,8 +103,8 @@ public class HelloResource {
     @Path("client")
     public String client(@HeaderParam("X-Propagated") String propagatedHeader,
             @HeaderParam("X-Not-Propagated") String nonPropagatedHeader) {
-        Assert.assertEquals("got-a-value", propagatedHeader);
-        Assert.assertEquals("got-a-value", nonPropagatedHeader);
+        Assertions.assertEquals("got-a-value", propagatedHeader);
+        Assertions.assertEquals("got-a-value", nonPropagatedHeader);
         return rest.clientTarget();
     }
 

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/microprofile/test/client/integration/resource/JsonpMPService.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/microprofile/test/client/integration/resource/JsonpMPService.java
@@ -31,7 +31,7 @@ import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 
 @Path("/jsonpService")
 public class JsonpMPService {
@@ -40,17 +40,17 @@ public class JsonpMPService {
     @Produces("application/json")
     @Consumes("application/json")
     public JsonArray array(JsonArray array) {
-        Assert.assertEquals("The request didn't contain 2 json elements", 2, array.size());
+        Assertions.assertEquals(2, array.size(), "The request didn't contain 2 json elements");
         JsonObject obj = array.getJsonObject(0);
-        Assert.assertTrue("The field 'name' didn't propagated correctly from the request for object[0]",
-                obj.containsKey("name"));
-        Assert.assertEquals("The value of field 'name' didn't propagated correctly from the request for object[0]",
-                obj.getJsonString("name").getString(), "Bill");
+        Assertions.assertTrue(obj.containsKey("name"),
+                "The field 'name' didn't propagated correctly from the request for object[0]");
+        Assertions.assertEquals(obj.getJsonString("name").getString(), "Bill",
+                "The value of field 'name' didn't propagated correctly from the request for object[0]");
         obj = array.getJsonObject(1);
-        Assert.assertTrue("The field 'name' didn't propagated correctly from the request for object[1]",
-                obj.containsKey("name"));
-        Assert.assertEquals("The value of field 'name' didn't propagated correctly from the request for object[1]",
-                obj.getJsonString("name").getString(), "Monica");
+        Assertions.assertTrue(obj.containsKey("name"),
+                "The field 'name' didn't propagated correctly from the request for object[1]");
+        Assertions.assertEquals(obj.getJsonString("name").getString(), "Monica",
+                "The value of field 'name' didn't propagated correctly from the request for object[1]");
         return array;
     }
 
@@ -59,12 +59,12 @@ public class JsonpMPService {
     @Produces("application/json")
     @Consumes("application/json")
     public JsonObject object(JsonObject obj) {
-        Assert.assertTrue("The field 'name' didn't propagated correctly from the request", obj.containsKey("name"));
-        Assert.assertEquals("The value of field 'name' didn't propagated correctly from the request",
-                obj.getJsonString("name").getString(), "Bill");
+        Assertions.assertTrue(obj.containsKey("name"), "The field 'name' didn't propagated correctly from the request");
+        Assertions.assertEquals(obj.getJsonString("name").getString(), "Bill",
+                "The value of field 'name' didn't propagated correctly from the request");
         if (obj.containsKey("id")) {
-            Assert.assertEquals("The value of field 'id' didn't propagated correctly from the request",
-                    obj.getJsonNumber("id").longValue(), 10001);
+            Assertions.assertEquals(obj.getJsonNumber("id").longValue(), 10001,
+                    "The value of field 'id' didn't propagated correctly from the request");
         }
         return obj;
     }
@@ -75,9 +75,9 @@ public class JsonpMPService {
     @Consumes("application/json")
     public JsonStructure object(JsonStructure struct) {
         JsonObject obj = (JsonObject) struct;
-        Assert.assertTrue("The field 'name' didn't propagated correctly from the request", obj.containsKey("name"));
-        Assert.assertEquals("The value of field 'name' didn't propagated correctly from the request",
-                obj.getJsonString("name").getString(), "Bill");
+        Assertions.assertTrue(obj.containsKey("name"), "The field 'name' didn't propagated correctly from the request");
+        Assertions.assertEquals(obj.getJsonString("name").getString(), "Bill",
+                "The value of field 'name' didn't propagated correctly from the request");
         return obj;
     }
 

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/microprofile/test/client/mapping/FeatureContextMapperTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/microprofile/test/client/mapping/FeatureContextMapperTest.java
@@ -36,19 +36,19 @@ import org.eclipse.microprofile.rest.client.ext.ResponseExceptionMapper;
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.resteasy.microprofile.test.util.TestEnvironment;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
  */
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 @RunAsClient
 public class FeatureContextMapperTest {
 
@@ -72,15 +72,15 @@ public class FeatureContextMapperTest {
         TestClient client = RestClientBuilder.newBuilder()
                 .baseUri(TestEnvironment.generateUri(url, "test-app"))
                 .build(TestClient.class);
-        Assert.assertNotNull(client);
+        Assertions.assertNotNull(client);
         try {
             final String value = client.test();
-            Assert.fail(String.format("Expected the client to throw a TestException but got a value of %s", value));
+            Assertions.fail(String.format("Expected the client to throw a TestException but got a value of %s", value));
         } catch (TestException expected) {
             final String msg = expected.getLocalizedMessage();
             final Response response = expected.getResponse();
-            Assert.assertEquals("test", msg);
-            Assert.assertEquals(Response.Status.NOT_IMPLEMENTED, response.getStatusInfo());
+            Assertions.assertEquals("test", msg);
+            Assertions.assertEquals(Response.Status.NOT_IMPLEMENTED, response.getStatusInfo());
         }
     }
 

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/microprofile/test/client/param/RESTEasyParamBasicTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/microprofile/test/client/param/RESTEasyParamBasicTest.java
@@ -24,7 +24,7 @@ import java.net.URL;
 import org.eclipse.microprofile.rest.client.RestClientBuilder;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.resteasy.microprofile.test.client.param.resource.Params;
 import org.jboss.resteasy.microprofile.test.client.param.resource.ProxyBeanParam;
@@ -33,9 +33,9 @@ import org.jboss.resteasy.microprofile.test.client.param.resource.ProxyParameter
 import org.jboss.resteasy.microprofile.test.client.param.resource.ProxyParameterAnotationsResource;
 import org.jboss.resteasy.microprofile.test.util.TestEnvironment;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * @tpSubChapter Parameters
@@ -44,7 +44,7 @@ import org.junit.runner.RunWith;
  *                    Test logic is in the end-point in deployment.
  * @tpSince RESTEasy 3.6
  */
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 @RunAsClient
 public class RESTEasyParamBasicTest {
 
@@ -81,7 +81,7 @@ public class RESTEasyParamBasicTest {
                 "pathParam0",
                 "formParam0",
                 "matrixParam0");
-        Assert.assertEquals("queryParam0 headerParam0 cookieParam0 pathParam0 formParam0 matrixParam0", response);
+        Assertions.assertEquals("queryParam0 headerParam0 cookieParam0 pathParam0 formParam0 matrixParam0", response);
     }
 
     /**
@@ -101,7 +101,7 @@ public class RESTEasyParamBasicTest {
                 .baseUri(TestEnvironment.generateUri(url, "test-app"))
                 .build(ProxyBeanParam.class);
         final String response = mpRestClient.getAll(params, "param2", "queryParam1");
-        Assert.assertEquals("test_param2_param3_queryParam_queryParam1", response);
+        Assertions.assertEquals("test_param2_param3_queryParam_queryParam1", response);
     }
 
 }

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/microprofile/test/config/ConfigConfigurationFactoryTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/microprofile/test/config/ConfigConfigurationFactoryTest.java
@@ -23,7 +23,7 @@ import java.lang.reflect.ReflectPermission;
 import java.util.PropertyPermission;
 
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.resteasy.microprofile.config.ConfigConfiguration;
 import org.jboss.resteasy.microprofile.test.config.resource.MicroProfileConfigResource;
 import org.jboss.resteasy.microprofile.test.config.resource.TestConfigApplication;
@@ -32,9 +32,9 @@ import org.jboss.resteasy.spi.config.ConfigurationFactory;
 import org.jboss.resteasy.utils.PermissionUtil;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * Tests that the {@link org.jboss.resteasy.microprofile.config.ConfigConfigurationFactory} is the one used inside
@@ -42,7 +42,7 @@ import org.junit.runner.RunWith;
  *
  * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
  */
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class ConfigConfigurationFactoryTest {
 
     @Deployment
@@ -60,7 +60,7 @@ public class ConfigConfigurationFactoryTest {
     @Test
     public void checkConfigurationFactory() {
         final ConfigurationFactory factory = ConfigurationFactory.getInstance();
-        Assert.assertTrue(String.format("Expected configuration %s to be an instance of ConfigConfiguration", factory),
-                factory.getConfiguration() instanceof ConfigConfiguration);
+        Assertions.assertTrue(factory.getConfiguration() instanceof ConfigConfiguration,
+                String.format("Expected configuration %s to be an instance of ConfigConfiguration", factory));
     }
 }

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/microprofile/test/config/ConfigSourceDefaultOrdinalFilterTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/microprofile/test/config/ConfigSourceDefaultOrdinalFilterTest.java
@@ -31,7 +31,7 @@ import jakarta.ws.rs.core.MediaType;
 
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.as.arquillian.api.ServerSetup;
 import org.jboss.resteasy.microprofile.config.FilterConfigSource;
@@ -43,18 +43,18 @@ import org.jboss.resteasy.microprofile.test.util.MicroProfileConfigSystemPropert
 import org.jboss.resteasy.microprofile.test.util.TestEnvironment;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * @tpSubChapter MicroProfile Config
  * @tpChapter Integration tests
  * @tpSince RESTEasy 4.6.0
  */
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 @RunAsClient
 @ServerSetup(MicroProfileConfigSystemPropertySetupTask.class)
 public class ConfigSourceDefaultOrdinalFilterTest {
@@ -72,12 +72,12 @@ public class ConfigSourceDefaultOrdinalFilterTest {
                 .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
     }
 
-    @BeforeClass
+    @BeforeAll
     public static void before() throws Exception {
         client = ClientBuilder.newClient();
     }
 
-    @AfterClass
+    @AfterAll
     public static void after() throws Exception {
         client.close();
     }
@@ -119,9 +119,9 @@ public class ConfigSourceDefaultOrdinalFilterTest {
         Integer filterConfigSourceDefaultOrdinal = 50;
         Integer servletContextConfigSourceDefaultOrdinal = 40;
 
-        Assert.assertEquals(filterConfigSourceDefaultOrdinal,
+        Assertions.assertEquals(filterConfigSourceDefaultOrdinal,
                 builtInConfigSourcesOrdinal.get(FilterConfigSource.class.getName()));
-        Assert.assertEquals(servletContextConfigSourceDefaultOrdinal,
+        Assertions.assertEquals(servletContextConfigSourceDefaultOrdinal,
                 builtInConfigSourcesOrdinal.get(ServletContextConfigSource.class
                         .getName()));
     }

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/microprofile/test/config/ConfigSourceDefaultOrdinalServletContextListenerTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/microprofile/test/config/ConfigSourceDefaultOrdinalServletContextListenerTest.java
@@ -31,7 +31,7 @@ import jakarta.ws.rs.core.MediaType;
 
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.as.arquillian.api.ServerSetup;
 import org.jboss.resteasy.microprofile.config.ServletConfigSource;
@@ -43,18 +43,18 @@ import org.jboss.resteasy.microprofile.test.util.MicroProfileConfigSystemPropert
 import org.jboss.resteasy.microprofile.test.util.TestEnvironment;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * @tpSubChapter MicroProfile Config
  * @tpChapter Integration tests
  * @tpSince RESTEasy 4.6.0
  */
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 @RunAsClient
 @ServerSetup(MicroProfileConfigSystemPropertySetupTask.class)
 public class ConfigSourceDefaultOrdinalServletContextListenerTest {
@@ -73,12 +73,12 @@ public class ConfigSourceDefaultOrdinalServletContextListenerTest {
                 .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
     }
 
-    @BeforeClass
+    @BeforeAll
     public static void before() throws Exception {
         client = ClientBuilder.newClient();
     }
 
-    @AfterClass
+    @AfterAll
     public static void after() throws Exception {
         client.close();
     }
@@ -120,9 +120,9 @@ public class ConfigSourceDefaultOrdinalServletContextListenerTest {
         Integer servletConfigSourceDefaultOrdinal = 60;
         Integer servletContextConfigSourceDefaultOrdinal = 40;
 
-        Assert.assertEquals(servletConfigSourceDefaultOrdinal, builtInConfigSourcesOrdinal.get(ServletConfigSource.class
+        Assertions.assertEquals(servletConfigSourceDefaultOrdinal, builtInConfigSourcesOrdinal.get(ServletConfigSource.class
                 .getName()));
-        Assert.assertEquals(servletContextConfigSourceDefaultOrdinal,
+        Assertions.assertEquals(servletContextConfigSourceDefaultOrdinal,
                 builtInConfigSourcesOrdinal.get(ServletContextConfigSource.class
                         .getName()));
     }

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/microprofile/test/config/ConfigSourceDefaultOrdinalServletTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/microprofile/test/config/ConfigSourceDefaultOrdinalServletTest.java
@@ -31,7 +31,7 @@ import jakarta.ws.rs.core.MediaType;
 
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.as.arquillian.api.ServerSetup;
 import org.jboss.resteasy.microprofile.config.ServletConfigSource;
@@ -43,18 +43,18 @@ import org.jboss.resteasy.microprofile.test.util.MicroProfileConfigSystemPropert
 import org.jboss.resteasy.microprofile.test.util.TestEnvironment;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * @tpSubChapter MicroProfile Config
  * @tpChapter Integration tests
  * @tpSince RESTEasy 4.6.0
  */
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 @RunAsClient
 @ServerSetup(MicroProfileConfigSystemPropertySetupTask.class)
 public class ConfigSourceDefaultOrdinalServletTest {
@@ -72,12 +72,12 @@ public class ConfigSourceDefaultOrdinalServletTest {
                 .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
     }
 
-    @BeforeClass
+    @BeforeAll
     public static void before() throws Exception {
         client = ClientBuilder.newClient();
     }
 
-    @AfterClass
+    @AfterAll
     public static void after() throws Exception {
         client.close();
     }
@@ -119,9 +119,9 @@ public class ConfigSourceDefaultOrdinalServletTest {
         Integer servletConfigSourceDefaultOrdinal = 60;
         Integer servletContextConfigSourceDefaultOrdinal = 40;
 
-        Assert.assertEquals(servletConfigSourceDefaultOrdinal, builtInConfigSourcesOrdinal.get(ServletConfigSource.class
+        Assertions.assertEquals(servletConfigSourceDefaultOrdinal, builtInConfigSourcesOrdinal.get(ServletConfigSource.class
                 .getName()));
-        Assert.assertEquals(servletContextConfigSourceDefaultOrdinal,
+        Assertions.assertEquals(servletContextConfigSourceDefaultOrdinal,
                 builtInConfigSourcesOrdinal.get(ServletContextConfigSource.class
                         .getName()));
     }

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/microprofile/test/config/ConfigSourceOverrideOrdinalFilterTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/microprofile/test/config/ConfigSourceOverrideOrdinalFilterTest.java
@@ -31,7 +31,7 @@ import jakarta.ws.rs.core.MediaType;
 
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.as.arquillian.api.ServerSetup;
 import org.jboss.resteasy.microprofile.config.FilterConfigSource;
@@ -43,18 +43,18 @@ import org.jboss.resteasy.microprofile.test.util.MicroProfileConfigSystemPropert
 import org.jboss.resteasy.microprofile.test.util.TestEnvironment;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * @tpSubChapter MicroProfile Config
  * @tpChapter Integration tests
  * @tpSince RESTEasy 4.6.0
  */
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 @RunAsClient
 @ServerSetup(MicroProfileConfigSystemPropertySetupTask.class)
 public class ConfigSourceOverrideOrdinalFilterTest {
@@ -72,12 +72,12 @@ public class ConfigSourceOverrideOrdinalFilterTest {
                 .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
     }
 
-    @BeforeClass
+    @BeforeAll
     public static void before() throws Exception {
         client = ClientBuilder.newClient();
     }
 
-    @AfterClass
+    @AfterAll
     public static void after() throws Exception {
         client.close();
     }
@@ -119,9 +119,9 @@ public class ConfigSourceOverrideOrdinalFilterTest {
         Integer filterConfigSourceDefaultOrdinal = 20;
         Integer servletContextConfigSourceDefaultOrdinal = 10;
 
-        Assert.assertEquals(filterConfigSourceDefaultOrdinal,
+        Assertions.assertEquals(filterConfigSourceDefaultOrdinal,
                 builtInConfigSourcesOrdinal.get(FilterConfigSource.class.getName()));
-        Assert.assertEquals(servletContextConfigSourceDefaultOrdinal,
+        Assertions.assertEquals(servletContextConfigSourceDefaultOrdinal,
                 builtInConfigSourcesOrdinal.get(ServletContextConfigSource.class
                         .getName()));
     }

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/microprofile/test/config/ConfigSourceOverrideOrdinalServletContextListenerTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/microprofile/test/config/ConfigSourceOverrideOrdinalServletContextListenerTest.java
@@ -31,7 +31,7 @@ import jakarta.ws.rs.core.MediaType;
 
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.as.arquillian.api.ServerSetup;
 import org.jboss.resteasy.microprofile.config.ServletConfigSource;
@@ -43,18 +43,18 @@ import org.jboss.resteasy.microprofile.test.util.MicroProfileConfigSystemPropert
 import org.jboss.resteasy.microprofile.test.util.TestEnvironment;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * @tpSubChapter MicroProfile Config
  * @tpChapter Integration tests
  * @tpSince RESTEasy 4.6.0
  */
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 @RunAsClient
 @ServerSetup(MicroProfileConfigSystemPropertySetupTask.class)
 public class ConfigSourceOverrideOrdinalServletContextListenerTest {
@@ -73,12 +73,12 @@ public class ConfigSourceOverrideOrdinalServletContextListenerTest {
                 .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
     }
 
-    @BeforeClass
+    @BeforeAll
     public static void before() throws Exception {
         client = ClientBuilder.newClient();
     }
 
-    @AfterClass
+    @AfterAll
     public static void after() throws Exception {
         client.close();
     }
@@ -120,9 +120,9 @@ public class ConfigSourceOverrideOrdinalServletContextListenerTest {
         Integer servletConfigSourceDefaultOrdinal = 30;
         Integer servletContextConfigSourceDefaultOrdinal = 10;
 
-        Assert.assertEquals(servletConfigSourceDefaultOrdinal, builtInConfigSourcesOrdinal.get(ServletConfigSource.class
+        Assertions.assertEquals(servletConfigSourceDefaultOrdinal, builtInConfigSourcesOrdinal.get(ServletConfigSource.class
                 .getName()));
-        Assert.assertEquals(servletContextConfigSourceDefaultOrdinal,
+        Assertions.assertEquals(servletContextConfigSourceDefaultOrdinal,
                 builtInConfigSourcesOrdinal.get(ServletContextConfigSource.class
                         .getName()));
     }

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/microprofile/test/config/ConfigSourceOverrideOrdinalServletTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/microprofile/test/config/ConfigSourceOverrideOrdinalServletTest.java
@@ -31,7 +31,7 @@ import jakarta.ws.rs.core.MediaType;
 
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.as.arquillian.api.ServerSetup;
 import org.jboss.resteasy.microprofile.config.ServletConfigSource;
@@ -43,18 +43,18 @@ import org.jboss.resteasy.microprofile.test.util.MicroProfileConfigSystemPropert
 import org.jboss.resteasy.microprofile.test.util.TestEnvironment;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * @tpSubChapter MicroProfile Config
  * @tpChapter Integration tests
  * @tpSince RESTEasy 4.6.0
  */
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 @RunAsClient
 @ServerSetup(MicroProfileConfigSystemPropertySetupTask.class)
 public class ConfigSourceOverrideOrdinalServletTest {
@@ -72,12 +72,12 @@ public class ConfigSourceOverrideOrdinalServletTest {
                 .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
     }
 
-    @BeforeClass
+    @BeforeAll
     public static void before() throws Exception {
         client = ClientBuilder.newClient();
     }
 
-    @AfterClass
+    @AfterAll
     public static void after() throws Exception {
         client.close();
     }
@@ -119,9 +119,9 @@ public class ConfigSourceOverrideOrdinalServletTest {
         Integer servletConfigSourceDefaultOrdinal = 30;
         Integer servletContextConfigSourceDefaultOrdinal = 10;
 
-        Assert.assertEquals(servletConfigSourceDefaultOrdinal, builtInConfigSourcesOrdinal.get(ServletConfigSource.class
+        Assertions.assertEquals(servletConfigSourceDefaultOrdinal, builtInConfigSourcesOrdinal.get(ServletConfigSource.class
                 .getName()));
-        Assert.assertEquals(servletContextConfigSourceDefaultOrdinal,
+        Assertions.assertEquals(servletContextConfigSourceDefaultOrdinal,
                 builtInConfigSourcesOrdinal.get(ServletContextConfigSource.class
                         .getName()));
     }

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/microprofile/test/config/MicroProfileConfigFilterTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/microprofile/test/config/MicroProfileConfigFilterTest.java
@@ -29,7 +29,7 @@ import jakarta.ws.rs.core.Response;
 
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.as.arquillian.api.ServerSetup;
 import org.jboss.resteasy.microprofile.test.config.resource.MicroProfileConfigFilter;
@@ -39,11 +39,11 @@ import org.jboss.resteasy.microprofile.test.util.MicroProfileConfigSystemPropert
 import org.jboss.resteasy.microprofile.test.util.TestEnvironment;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * @tpSubChapter MicroProfile Config
@@ -51,7 +51,7 @@ import org.junit.runner.RunWith;
  * @tpTestCaseDetails Regression tests for RESTEASY-2131
  * @tpSince RESTEasy 4.0.0
  */
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 @RunAsClient
 @ServerSetup(MicroProfileConfigSystemPropertySetupTask.class)
 public class MicroProfileConfigFilterTest {
@@ -69,12 +69,12 @@ public class MicroProfileConfigFilterTest {
                 .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
     }
 
-    @BeforeClass
+    @BeforeAll
     public static void before() throws Exception {
         client = ClientBuilder.newClient();
     }
 
-    @AfterClass
+    @AfterAll
     public static void after() throws Exception {
         client.close();
     }
@@ -90,8 +90,8 @@ public class MicroProfileConfigFilterTest {
     @Test
     public void testSystemProgrammatic() throws Exception {
         Response response = client.target(generateURL("/system/prog")).request().get();
-        Assert.assertEquals(200, response.getStatus());
-        Assert.assertEquals("system-system", response.readEntity(String.class));
+        Assertions.assertEquals(200, response.getStatus());
+        Assertions.assertEquals("system-system", response.readEntity(String.class));
     }
 
     /**
@@ -101,8 +101,8 @@ public class MicroProfileConfigFilterTest {
     @Test
     public void testSystemInject() throws Exception {
         Response response = client.target(generateURL("/system/inject")).request().get();
-        Assert.assertEquals(200, response.getStatus());
-        Assert.assertEquals("system-system", response.readEntity(String.class));
+        Assertions.assertEquals(200, response.getStatus());
+        Assertions.assertEquals("system-system", response.readEntity(String.class));
     }
 
     /**
@@ -113,8 +113,8 @@ public class MicroProfileConfigFilterTest {
     @Test
     public void testFilterProgrammatic() throws Exception {
         Response response = client.target(generateURL("/filter/prog")).request().get();
-        Assert.assertEquals(200, response.getStatus());
-        Assert.assertEquals("filter-filter", response.readEntity(String.class));
+        Assertions.assertEquals(200, response.getStatus());
+        Assertions.assertEquals("filter-filter", response.readEntity(String.class));
     }
 
     /**
@@ -125,8 +125,8 @@ public class MicroProfileConfigFilterTest {
     @Test
     public void testFilterInject() throws Exception {
         Response response = client.target(generateURL("/filter/inject")).request().get();
-        Assert.assertEquals(200, response.getStatus());
-        Assert.assertEquals("filter-filter", response.readEntity(String.class));
+        Assertions.assertEquals(200, response.getStatus());
+        Assertions.assertEquals("filter-filter", response.readEntity(String.class));
     }
 
     /**
@@ -136,8 +136,8 @@ public class MicroProfileConfigFilterTest {
     @Test
     public void testContextProgrammatic() throws Exception {
         Response response = client.target(generateURL("/context/prog")).request().get();
-        Assert.assertEquals(200, response.getStatus());
-        Assert.assertEquals("context-context", response.readEntity(String.class));
+        Assertions.assertEquals(200, response.getStatus());
+        Assertions.assertEquals("context-context", response.readEntity(String.class));
     }
 
     /**
@@ -147,8 +147,8 @@ public class MicroProfileConfigFilterTest {
     @Test
     public void testContextInject() throws Exception {
         Response response = client.target(generateURL("/context/inject")).request().get();
-        Assert.assertEquals(200, response.getStatus());
-        Assert.assertEquals("context-context", response.readEntity(String.class));
+        Assertions.assertEquals(200, response.getStatus());
+        Assertions.assertEquals("context-context", response.readEntity(String.class));
     }
 
     /**
@@ -158,7 +158,7 @@ public class MicroProfileConfigFilterTest {
     @Test
     public void testActualContextParameter() throws Exception {
         Response response = client.target(generateURL("/actual")).request().get();
-        Assert.assertEquals(200, response.getStatus());
-        Assert.assertEquals("text/plain", response.getHeaderString("Content-Type"));
+        Assertions.assertEquals(200, response.getStatus());
+        Assertions.assertEquals("text/plain", response.getHeaderString("Content-Type"));
     }
 }

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/microprofile/test/config/MicroProfileConfigServletContextListenerTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/microprofile/test/config/MicroProfileConfigServletContextListenerTest.java
@@ -29,7 +29,7 @@ import jakarta.ws.rs.core.Response;
 
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.as.arquillian.api.ServerSetup;
 import org.jboss.resteasy.microprofile.test.config.resource.MicroProfileConfigFilter;
@@ -39,11 +39,11 @@ import org.jboss.resteasy.microprofile.test.util.MicroProfileConfigSystemPropert
 import org.jboss.resteasy.microprofile.test.util.TestEnvironment;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * @tpSubChapter MicroProfile Config
@@ -51,7 +51,7 @@ import org.junit.runner.RunWith;
  * @tpTestCaseDetails Regression tests for RESTEASY-2131
  * @tpSince RESTEasy 4.0.0
  */
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 @RunAsClient
 @ServerSetup(MicroProfileConfigSystemPropertySetupTask.class)
 public class MicroProfileConfigServletContextListenerTest {
@@ -69,12 +69,12 @@ public class MicroProfileConfigServletContextListenerTest {
                 .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
     }
 
-    @BeforeClass
+    @BeforeAll
     public static void before() throws Exception {
         client = ClientBuilder.newClient();
     }
 
-    @AfterClass
+    @AfterAll
     public static void after() throws Exception {
         client.close();
     }
@@ -90,8 +90,8 @@ public class MicroProfileConfigServletContextListenerTest {
     @Test
     public void testSystemProgrammatic() throws Exception {
         Response response = client.target(generateURL("/system/prog")).request().get();
-        Assert.assertEquals(200, response.getStatus());
-        Assert.assertEquals("system-system", response.readEntity(String.class));
+        Assertions.assertEquals(200, response.getStatus());
+        Assertions.assertEquals("system-system", response.readEntity(String.class));
     }
 
     /**
@@ -101,8 +101,8 @@ public class MicroProfileConfigServletContextListenerTest {
     @Test
     public void testSystemInject() throws Exception {
         Response response = client.target(generateURL("/system/inject")).request().get();
-        Assert.assertEquals(200, response.getStatus());
-        Assert.assertEquals("system-system", response.readEntity(String.class));
+        Assertions.assertEquals(200, response.getStatus());
+        Assertions.assertEquals("system-system", response.readEntity(String.class));
     }
 
     /**
@@ -113,8 +113,8 @@ public class MicroProfileConfigServletContextListenerTest {
     @Test
     public void testInitProgrammatic() throws Exception {
         Response response = client.target(generateURL("/init/prog")).request().get();
-        Assert.assertEquals(200, response.getStatus());
-        Assert.assertEquals("init-init", response.readEntity(String.class));
+        Assertions.assertEquals(200, response.getStatus());
+        Assertions.assertEquals("init-init", response.readEntity(String.class));
     }
 
     /**
@@ -125,8 +125,8 @@ public class MicroProfileConfigServletContextListenerTest {
     @Test
     public void testInitInject() throws Exception {
         Response response = client.target(generateURL("/init/inject")).request().get();
-        Assert.assertEquals(200, response.getStatus());
-        Assert.assertEquals("init-init", response.readEntity(String.class));
+        Assertions.assertEquals(200, response.getStatus());
+        Assertions.assertEquals("init-init", response.readEntity(String.class));
     }
 
     /**
@@ -136,8 +136,8 @@ public class MicroProfileConfigServletContextListenerTest {
     @Test
     public void testContextProgrammatic() throws Exception {
         Response response = client.target(generateURL("/context/prog")).request().get();
-        Assert.assertEquals(200, response.getStatus());
-        Assert.assertEquals("context-context", response.readEntity(String.class));
+        Assertions.assertEquals(200, response.getStatus());
+        Assertions.assertEquals("context-context", response.readEntity(String.class));
     }
 
     /**
@@ -147,7 +147,7 @@ public class MicroProfileConfigServletContextListenerTest {
     @Test
     public void testContextInject() throws Exception {
         Response response = client.target(generateURL("/context/inject")).request().get();
-        Assert.assertEquals(200, response.getStatus());
-        Assert.assertEquals("context-context", response.readEntity(String.class));
+        Assertions.assertEquals(200, response.getStatus());
+        Assertions.assertEquals("context-context", response.readEntity(String.class));
     }
 }

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/microprofile/test/config/MicroProfileConfigServletTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/microprofile/test/config/MicroProfileConfigServletTest.java
@@ -29,7 +29,7 @@ import jakarta.ws.rs.core.Response;
 
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.as.arquillian.api.ServerSetup;
 import org.jboss.resteasy.microprofile.test.config.resource.MicroProfileConfigFilter;
@@ -39,11 +39,11 @@ import org.jboss.resteasy.microprofile.test.util.MicroProfileConfigSystemPropert
 import org.jboss.resteasy.microprofile.test.util.TestEnvironment;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * @tpSubChapter MicroProfile Config
@@ -51,7 +51,7 @@ import org.junit.runner.RunWith;
  * @tpTestCaseDetails Regression tests for RESTEASY-2131
  * @tpSince RESTEasy 4.0.0
  */
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 @RunAsClient
 @ServerSetup(MicroProfileConfigSystemPropertySetupTask.class)
 public class MicroProfileConfigServletTest {
@@ -68,12 +68,12 @@ public class MicroProfileConfigServletTest {
                 .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
     }
 
-    @BeforeClass
+    @BeforeAll
     public static void before() throws Exception {
         client = ClientBuilder.newClient();
     }
 
-    @AfterClass
+    @AfterAll
     public static void after() throws Exception {
         client.close();
     }
@@ -89,8 +89,8 @@ public class MicroProfileConfigServletTest {
     @Test
     public void testSystemProgrammatic() throws Exception {
         Response response = client.target(generateURL("/system/prog")).request().get();
-        Assert.assertEquals(200, response.getStatus());
-        Assert.assertEquals("system-system", response.readEntity(String.class));
+        Assertions.assertEquals(200, response.getStatus());
+        Assertions.assertEquals("system-system", response.readEntity(String.class));
     }
 
     /**
@@ -100,8 +100,8 @@ public class MicroProfileConfigServletTest {
     @Test
     public void testSystemInject() throws Exception {
         Response response = client.target(generateURL("/system/inject")).request().get();
-        Assert.assertEquals(200, response.getStatus());
-        Assert.assertEquals("system-system", response.readEntity(String.class));
+        Assertions.assertEquals(200, response.getStatus());
+        Assertions.assertEquals("system-system", response.readEntity(String.class));
     }
 
     /**
@@ -112,8 +112,8 @@ public class MicroProfileConfigServletTest {
     @Test
     public void testInitProgrammatic() throws Exception {
         Response response = client.target(generateURL("/init/prog")).request().get();
-        Assert.assertEquals(200, response.getStatus());
-        Assert.assertEquals("init-init", response.readEntity(String.class));
+        Assertions.assertEquals(200, response.getStatus());
+        Assertions.assertEquals("init-init", response.readEntity(String.class));
     }
 
     /**
@@ -124,8 +124,8 @@ public class MicroProfileConfigServletTest {
     @Test
     public void testInitInject() throws Exception {
         Response response = client.target(generateURL("/init/inject")).request().get();
-        Assert.assertEquals(200, response.getStatus());
-        Assert.assertEquals("init-init", response.readEntity(String.class));
+        Assertions.assertEquals(200, response.getStatus());
+        Assertions.assertEquals("init-init", response.readEntity(String.class));
     }
 
     /**
@@ -135,8 +135,8 @@ public class MicroProfileConfigServletTest {
     @Test
     public void testContextProgrammatic() throws Exception {
         Response response = client.target(generateURL("/context/prog")).request().get();
-        Assert.assertEquals(200, response.getStatus());
-        Assert.assertEquals("context-context", response.readEntity(String.class));
+        Assertions.assertEquals(200, response.getStatus());
+        Assertions.assertEquals("context-context", response.readEntity(String.class));
     }
 
     /**
@@ -146,8 +146,8 @@ public class MicroProfileConfigServletTest {
     @Test
     public void testContextInject() throws Exception {
         Response response = client.target(generateURL("/context/inject")).request().get();
-        Assert.assertEquals(200, response.getStatus());
-        Assert.assertEquals("context-context", response.readEntity(String.class));
+        Assertions.assertEquals(200, response.getStatus());
+        Assertions.assertEquals("context-context", response.readEntity(String.class));
     }
 
     /**
@@ -157,7 +157,7 @@ public class MicroProfileConfigServletTest {
     @Test
     public void testActualContextParameter() throws Exception {
         Response response = client.target(generateURL("/actual")).request().get();
-        Assert.assertEquals(200, response.getStatus());
-        Assert.assertEquals("text/plain", response.getHeaderString("Content-Type"));
+        Assertions.assertEquals(200, response.getStatus());
+        Assertions.assertEquals("text/plain", response.getHeaderString("Content-Type"));
     }
 }

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/microprofile/test/config/MicroProfileConfigUseGlobalTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/microprofile/test/config/MicroProfileConfigUseGlobalTest.java
@@ -27,7 +27,7 @@ import jakarta.ws.rs.core.Response;
 
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.resteasy.microprofile.test.config.resource.MicroProfileConfigUseGlobalApplication1;
 import org.jboss.resteasy.microprofile.test.config.resource.MicroProfileConfigUseGlobalApplication2;
@@ -35,11 +35,11 @@ import org.jboss.resteasy.microprofile.test.config.resource.MicroProfileConfigUs
 import org.jboss.resteasy.microprofile.test.util.TestEnvironment;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * @tpSubChapter MicroProfile Config: ServletConfig with useGlobal and multiple servlets
@@ -47,7 +47,7 @@ import org.junit.runner.RunWith;
  * @tpTestCaseDetails Regression tests for RESTEASY-2266
  * @tpSince RESTEasy 4.1.0
  */
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 @RunAsClient
 public class MicroProfileConfigUseGlobalTest {
 
@@ -65,12 +65,12 @@ public class MicroProfileConfigUseGlobalTest {
                 .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
     }
 
-    @BeforeClass
+    @BeforeAll
     public static void before() throws Exception {
         client = ClientBuilder.newClient();
     }
 
-    @AfterClass
+    @AfterAll
     public static void after() throws Exception {
         client.close();
     }
@@ -82,10 +82,10 @@ public class MicroProfileConfigUseGlobalTest {
     @Test
     public void testMultipleAppsUseGlobal() throws Exception {
         Response response = client.target(TestEnvironment.generateUri(url, "/app1/prefix")).request().get();
-        Assert.assertEquals(200, response.getStatus());
-        Assert.assertEquals("/app1", response.readEntity(String.class));
+        Assertions.assertEquals(200, response.getStatus());
+        Assertions.assertEquals("/app1", response.readEntity(String.class));
         response = client.target(TestEnvironment.generateUri(url, "/app2/prefix")).request().get();
-        Assert.assertEquals(200, response.getStatus());
-        Assert.assertEquals("/app2", response.readEntity(String.class));
+        Assertions.assertEquals(200, response.getStatus());
+        Assertions.assertEquals("/app2", response.readEntity(String.class));
     }
 }

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/microprofile/test/config/OptionalConfigPropertyInjectionTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/microprofile/test/config/OptionalConfigPropertyInjectionTest.java
@@ -28,7 +28,7 @@ import jakarta.ws.rs.core.MediaType;
 
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.as.arquillian.api.ServerSetup;
 import org.jboss.resteasy.microprofile.test.config.resource.OptionalConfigPropertyInjectionResource;
@@ -36,11 +36,11 @@ import org.jboss.resteasy.microprofile.test.util.TestEnvironment;
 import org.jboss.resteasy.setup.SystemPropertySetupTask;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * @tpSubChapter MicroProfile Config
@@ -48,7 +48,7 @@ import org.junit.runner.RunWith;
  * @tpTestCaseDetails Test for injection of optional MicroProfile Config properties.
  * @tpSince RESTEasy 4.6.0
  */
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 @RunAsClient
 @ServerSetup(OptionalConfigPropertyInjectionTest.PropertySetupTask.class)
 public class OptionalConfigPropertyInjectionTest {
@@ -72,12 +72,12 @@ public class OptionalConfigPropertyInjectionTest {
                 .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
     }
 
-    @BeforeClass
+    @BeforeAll
     public static void setup() {
         client = ClientBuilder.newClient();
     }
 
-    @AfterClass
+    @AfterAll
     public static void cleanup() {
         client.close();
     }
@@ -96,14 +96,14 @@ public class OptionalConfigPropertyInjectionTest {
                         OptionalConfigPropertyInjectionResource.MISSING_OPTIONAL_PROPERTY_PATH))
                 .request(MediaType.TEXT_PLAIN_TYPE)
                 .get(String.class);
-        Assert.assertNull(missingOptionalPropertyValue);
+        Assertions.assertNull(missingOptionalPropertyValue);
 
         String presentOptionalPropertyValue = client.target(
                 TestEnvironment.generateUri(url, "test-app",
                         OptionalConfigPropertyInjectionResource.PRESENT_OPTIONAL_PROPERTY_PATH))
                 .request(MediaType.TEXT_PLAIN_TYPE)
                 .get(String.class);
-        Assert.assertEquals(OptionalConfigPropertyInjectionResource.OPTIONAL_PROPERTY_VALUE, presentOptionalPropertyValue);
+        Assertions.assertEquals(OptionalConfigPropertyInjectionResource.OPTIONAL_PROPERTY_VALUE, presentOptionalPropertyValue);
     }
 
 }

--- a/testsuite/microprofile-rest-client-tck/pom.xml
+++ b/testsuite/microprofile-rest-client-tck/pom.xml
@@ -66,6 +66,7 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
+            <version>${version.junit}</version>
             <scope>test</scope>
         </dependency>
 
@@ -102,6 +103,12 @@
             <groupId>org.jboss.arquillian.container</groupId>
             <artifactId>arquillian-weld-embedded</artifactId>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>jakarta.el</groupId>
+                    <artifactId>jakarta.el-api</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -33,6 +33,7 @@
     <name>RESTEasy MicroProfile: Test Suite</name>
     <properties>
         <jvm.debug.args/>
+        <dep.arquillian-bom.version>1.7.2.Final</dep.arquillian-bom.version>
     </properties>
     <modules>
         <module>integration-tests</module>
@@ -54,6 +55,13 @@
                 <version>${project.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.jboss.arquillian</groupId>
+                <artifactId>arquillian-bom</artifactId>
+                <version>${dep.arquillian-bom.version}</version>
+                <scope>import</scope>
+                <type>pom</type>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
The junit4 dependencies remain in microprofile-rest-client-tck as I assume the tck is still using junit4.