### PR TITLE
WildFly 35+ will require a minimum of Java 17. Update the nightly Wil…

### DIFF
--- a/.github/workflows/wildfly-build.yml
+++ b/.github/workflows/wildfly-build.yml
@@ -31,30 +31,19 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  wildfly-build:
-    uses: wildfly/wildfly/.github/workflows/shared-wildfly-build.yml@main
-    with:
-      wildfly-branch: "main"
-      wildfly-repo: "wildfly/wildfly"
 
   resteasy-build:
     runs-on: ${{ matrix.os }}
-    needs: wildfly-build
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
-        java: ['11', '17', '21']
+        java: ['17', '21']
 
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/download-artifact@v4
-        with:
-          name: wildfly-maven-repository
-          path: .
-      - name: Extract Maven Repo
-        shell: bash
-        run: tar -xzf wildfly-maven-repository.tar.gz -C ~
+      - uses: wildfly-extras/wildfly-nightly-download@v1
+        id: wildfly-nightly
       - name: Set up JDK ${{ matrix.java }}
         uses: actions/setup-java@v4
         with:
@@ -62,7 +51,7 @@ jobs:
           distribution: 'temurin'
           cache: 'maven'
       - name: Build with Maven Java ${{ matrix.java }}
-        run: mvn  -B clean install '-Dserver.version=${{ needs.wildfly-build.outputs.wildfly-version }}'
+        run: mvn  -B clean install '-Dserver.version=${{ steps.wildfly-nightly.outputs.wildfly-version }}'
       - name: Upload surefire reports
         uses: actions/upload-artifact@v4
         if: failure()


### PR DESCRIPTION
…dFly build to only test on Java 17 and 21 and use the new GitHub Action to download the Maven Repository.