### PR TITLE
[395] Since the Vertx client is used in the test suite and now client…

### DIFF
--- a/testsuite/integration-tests/pom.xml
+++ b/testsuite/integration-tests/pom.xml
@@ -224,6 +224,31 @@
                         <jboss.home>${jboss.home}</jboss.home>
                     </systemPropertyVariables>
                 </configuration>
+                <executions>
+                    <execution>
+                        <id>default-test</id>
+                        <goals>
+                            <goal>test</goal>
+                        </goals>
+                        <phase>test</phase>
+                        <configuration>
+                            <classpathDependencyExcludes>
+                                <exclude>org.jboss.resteasy:resteasy-client-vertx</exclude>
+                            </classpathDependencyExcludes>
+                            <excludedGroups>vertx</excludedGroups>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>vertx-tests</id>
+                        <goals>
+                            <goal>test</goal>
+                        </goals>
+                        <phase>test</phase>
+                        <configuration>
+                            <groups>vertx</groups>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
             <plugin>
                 <groupId>org.wildfly.plugins</groupId>

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/microprofile/test/client/integration/RestClientProxyTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/microprofile/test/client/integration/RestClientProxyTest.java
@@ -59,6 +59,7 @@ import org.jboss.resteasy.microprofile.test.util.TestEnvironment;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
@@ -68,6 +69,8 @@ import io.vertx.core.http.HttpVersion;
 
 @ExtendWith(ArquillianExtension.class)
 @RunAsClient
+@Tag("http2")
+@Tag("vertx")
 public class RestClientProxyTest {
 
     public static final String EMOJIS = "\uD83D\uDE00\uD83D\uDE00\uD83D\uDE00\uD83D\uDE00\uD83D\uDE00\uD83D\uDE00\uD83D\uDE00\uD83D\uDE00";


### PR DESCRIPTION
…s are automatically registered, we need to execute tests in different contexts.

resolves #395 
Upstream: #396 