### PR TITLE
Global and Per-client properties to disable default ResponseExceptionMappe

### DIFF
--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/microprofile/test/client/exception/ResponseDisableExceptionTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/microprofile/test/client/exception/ResponseDisableExceptionTest.java
@@ -1,0 +1,71 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2024 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.resteasy.microprofile.test.client.exception;
+
+import java.net.URL;
+
+import jakarta.ws.rs.BadRequestException;
+import jakarta.ws.rs.core.Response;
+
+import org.eclipse.microprofile.rest.client.RestClientBuilder;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.resteasy.microprofile.test.client.exception.resource.ProxyExceptionFactory;
+import org.jboss.resteasy.microprofile.test.client.exception.resource.ProxyExceptionResource;
+import org.jboss.resteasy.microprofile.test.util.TestEnvironment;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith(ArquillianExtension.class)
+@RunAsClient
+public class ResponseDisableExceptionTest {
+
+    @ArquillianResource
+    private URL url;
+
+    @Deployment
+    public static Archive<?> deploySimpleResource() {
+        return TestEnvironment.createWar(ResponseDisableExceptionTest.class)
+                .addClasses(ProxyExceptionResource.class);
+    }
+
+    /**
+     * response and exception mapping
+     */
+    @Test
+    public void testResponseExceptions() throws Exception {
+        System.setProperty("microprofile.rest.client.disable.response.exceptions", "true");
+        try {
+            ProxyExceptionFactory mpRestClient = RestClientBuilder.newBuilder()
+                    .baseUri(TestEnvironment.generateUri(url, "test-app"))
+                    .build(ProxyExceptionFactory.class);
+            Assertions.assertThrows(BadRequestException.class,
+                    () -> mpRestClient.asException(400, "Bad Parameter"));
+            Response response = mpRestClient.asResponse(400, "Bad Parameter");
+            Assertions.assertEquals(400, response.getStatusInfo().getStatusCode());
+        } finally {
+            System.clearProperty("microprofile.rest.client.disable.response.exceptions");
+        }
+    }
+}

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/microprofile/test/client/exception/resource/ProxyExceptionFactory.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/microprofile/test/client/exception/resource/ProxyExceptionFactory.java
@@ -17,22 +17,22 @@
  * limitations under the License.
  */
 
-package org.jboss.resteasy.microprofile.test.client.integration.resource;
-
-import java.io.Closeable;
+package org.jboss.resteasy.microprofile.test.client.exception.resource;
 
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
-import jakarta.ws.rs.Produces;
-import jakarta.ws.rs.WebApplicationException;
-import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.Response;
 
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
 
-@RegisterRestClient(configKey = "HealthService")
-public interface HealthService extends Closeable {
+@Path("/exception")
+@RegisterRestClient
+public interface ProxyExceptionFactory {
+
     @GET
-    @Produces({ MediaType.APPLICATION_JSON })
-    @Path("/health")
-    HealthCheckData getHealthData() throws WebApplicationException;
+    Response asResponse(@QueryParam("status") int status, @QueryParam("reason") String reason);
+
+    @GET
+    String asException(@QueryParam("status") int status, @QueryParam("reason") String reason);
 }

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/microprofile/test/client/exception/resource/ProxyExceptionResource.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/microprofile/test/client/exception/resource/ProxyExceptionResource.java
@@ -17,22 +17,18 @@
  * limitations under the License.
  */
 
-package org.jboss.resteasy.microprofile.test.client.integration.resource;
-
-import java.io.Closeable;
+package org.jboss.resteasy.microprofile.test.client.exception.resource;
 
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
-import jakarta.ws.rs.Produces;
-import jakarta.ws.rs.WebApplicationException;
-import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.Response;
 
-import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+@Path("/exception")
+public class ProxyExceptionResource {
 
-@RegisterRestClient(configKey = "HealthService")
-public interface HealthService extends Closeable {
     @GET
-    @Produces({ MediaType.APPLICATION_JSON })
-    @Path("/health")
-    HealthCheckData getHealthData() throws WebApplicationException;
+    public Response asResponse(@QueryParam("status") int status, @QueryParam("reason") String reason) {
+        return Response.status(status, reason).build();
+    }
 }


### PR DESCRIPTION
Global and Per-client properties to disable default ResponseExceptionMapper
and properties to disable invoking ResponseExceptionMapper when method return type is jakarta.ws.rs.core.Response

documentation will need to be updated downstream:

New property effective in both programatic client api and global config:
microprofile.rest.client.disable.response.exceptions - disables invoking client exception mapper when the proxy method return type is akarta.ws.rs.core.Response

New annotation keyed properties:
{fqcn | key}/mp-rest/disableResponseExceptions - per client `microprofile.rest.client.disable.response.exceptions` configuration
{fqcn | key}/mp-rest/disableDefaultMapper - per client `microprofile.rest.client.disable.default.mapper` configuration

Closes #23957, #44813