### PR TITLE
Upgrade RESTEasy from 6.2.12.Final to 6.2.14.Final. Migrate to the ne…

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,6 +17,8 @@ updates:
         update-types: ['version-update:semver-major', 'version-update:semver-minor']
       - dependency-name: 'jakarta.servlet:jakarta.servlet-api'
         update-types: ['version-update:semver-major', 'version-update:semver-minor']
+      - dependency-name: 'org.jboss.resteasy:*'
+        update-types: ['version-update:semver-major', 'version-update:semver-minor']
       - dependency-name: 'org.eclipse.jetty:*'
         update-types: ['version-update:semver-major']
       - dependency-name: 'org.jboss.weld.se:*'

--- a/bom/test-bom/pom.xml
+++ b/bom/test-bom/pom.xml
@@ -34,6 +34,7 @@
     <name>RESTEasy MicroProfile: Test BOM</name>
 
     <properties>
+        <version.dev.resteasy.vertx>1.0.1.Final</version.dev.resteasy.vertx>
 
         <version.jakarta.enterprise.concurrent>2.0.0</version.jakarta.enterprise.concurrent>
         <version.jakarta.json.json-api>2.1.3</version.jakarta.json.json-api>
@@ -103,6 +104,13 @@
                 <groupId>org.wiremock</groupId>
                 <artifactId>wiremock</artifactId>
                 <version>${version.org.wiremock}</version>
+                <scope>test</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>dev.resteasy.vertx</groupId>
+                <artifactId>resteasy-vertx-client</artifactId>
+                <version>${version.dev.resteasy.vertx}</version>
                 <scope>test</scope>
             </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
 
         <version.org.jboss.logging.jboss-logging>3.6.1.Final</version.org.jboss.logging.jboss-logging>
         <version.org.jboss.logging.jboss-logging-tools>3.0.4.Final</version.org.jboss.logging.jboss-logging-tools>
-        <version.org.jboss.resteasy>6.2.12.Final</version.org.jboss.resteasy>
+        <version.org.jboss.resteasy>6.2.14.Final</version.org.jboss.resteasy>
 
         <version.junit>4.13.2</version.junit>
         <version.org.junit>5.13.4</version.org.junit>

--- a/rest-client/pom.xml
+++ b/rest-client/pom.xml
@@ -97,6 +97,24 @@
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-undertow</artifactId>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>io.smallrye.common</groupId>
+                    <artifactId>smallrye-common-annotation</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>io.smallrye.common</groupId>
+                    <artifactId>smallrye-common-constraint</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>io.smallrye.common</groupId>
+                    <artifactId>smallrye-common-expression</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>io.smallrye.common</groupId>
+                    <artifactId>smallrye-common-function</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>

--- a/testsuite/integration-tests/pom.xml
+++ b/testsuite/integration-tests/pom.xml
@@ -64,9 +64,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.jboss.resteasy</groupId>
-            <artifactId>resteasy-client-vertx</artifactId>
-            <version>${version.org.jboss.resteasy}</version>
+            <groupId>dev.resteasy.vertx</groupId>
+            <artifactId>resteasy-vertx-client</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -217,7 +216,7 @@
                         <phase>test</phase>
                         <configuration>
                             <classpathDependencyExcludes>
-                                <exclude>org.jboss.resteasy:resteasy-client-vertx</exclude>
+                                <exclude>dev.resteasy.vertx:*</exclude>
                             </classpathDependencyExcludes>
                             <excludedGroups>vertx</excludedGroups>
                         </configuration>


### PR DESCRIPTION
…w RESTEasy Vert.x and only allow patch upgrades for RESTEasy.