### PR TITLE
[506] Upgrade to RESTEasy 6.2.15.Final. Use the new channel group ID …

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -121,13 +121,13 @@ https://docs.wildfly.org/galleon/[Galleon] tooling to do so.
             <!-- Not required, but will get you the latest version of RESTEasy -->
             <channel>
                 <manifest>
-                    <groupId>dev.resteasy.channels</groupId>
+                    <groupId>org.jboss.resteasy.channels</groupId>
                     <artifactId>resteasy-6.2</artifactId>
                 </manifest>
             </channel>
             <channel>
                 <manifest>
-                    <groupId>dev.resteasy.channels</groupId>
+                    <groupId>org.jboss.channels</groupId>
                     <artifactId>resteasy-microprofile-3.0</artifactId>
                 </manifest>
             </channel>

--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
 
         <version.org.jboss.logging.jboss-logging>3.6.1.Final</version.org.jboss.logging.jboss-logging>
         <version.org.jboss.logging.jboss-logging-tools>3.0.4.Final</version.org.jboss.logging.jboss-logging-tools>
-        <version.org.jboss.resteasy>6.2.14.Final</version.org.jboss.resteasy>
+        <version.org.jboss.resteasy>6.2.15.Final</version.org.jboss.resteasy>
 
         <version.junit>4.13.2</version.junit>
         <version.org.junit>5.13.4</version.org.junit>

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -47,11 +47,11 @@
         <wildfly.channel.manifest.groupId>org.wildfly.channels</wildfly.channel.manifest.groupId>
         <wildfly.channel.manifest.artifactId>wildfly</wildfly.channel.manifest.artifactId>
 
-        <resteasy.channel.manifest.groupId>dev.resteasy.channels</resteasy.channel.manifest.groupId>
+        <resteasy.channel.manifest.groupId>org.jboss.resteasy.channels</resteasy.channel.manifest.groupId>
         <resteasy.channel.manifest.artifactId>resteasy-6.2</resteasy.channel.manifest.artifactId>
         <resteasy.channel.manifest.version>${version.org.jboss.resteasy}</resteasy.channel.manifest.version>
 
-        <resteasy.mp.channel.manifest.groupId>dev.resteasy.channels</resteasy.mp.channel.manifest.groupId>
+        <resteasy.mp.channel.manifest.groupId>org.jboss.resteasy.channels</resteasy.mp.channel.manifest.groupId>
         <resteasy.mp.channel.manifest.artifactId>resteasy-microprofile-${channel.stream.version}</resteasy.mp.channel.manifest.artifactId>
         <resteasy.mp.channel.manifest.version>${project.version}</resteasy.mp.channel.manifest.version>
         <jboss.arguments/>

--- a/wildfly/resteasy-microprofile-channel/pom.xml
+++ b/wildfly/resteasy-microprofile-channel/pom.xml
@@ -29,7 +29,7 @@
         <relativePath>../../pom.xml</relativePath>
     </parent>
 
-    <groupId>dev.resteasy.channels</groupId>
+    <groupId>org.jboss.resteasy.channels</groupId>
     <artifactId>resteasy-microprofile-3.0</artifactId>
     <name>RESTEasy MicroProfile: Channel Manifest</name>
     <packaging>pom</packaging>


### PR DESCRIPTION
…and migrate this project to also use this new group ID in preparation for the new release procedure.