### PR TITLE
Fixes RestClientBuilderImpl.verifyInterface when @Path annotation val…

### DIFF
--- a/rest-client-base/src/main/java/org/jboss/resteasy/microprofile/client/RestClientBuilderImpl.java
+++ b/rest-client-base/src/main/java/org/jboss/resteasy/microprofile/client/RestClientBuilderImpl.java
@@ -606,9 +606,9 @@ public class RestClientBuilderImpl implements RestClientBuilder {
             if (methodPathAnno != null) {
                 template = classPathAnno == null ? (ResteasyUriBuilder) new ResteasyUriBuilderImpl().uri(methodPathAnno.value())
                         : (ResteasyUriBuilder) new ResteasyUriBuilderImpl()
-                                .uri(classPathAnno.value() + "/" + methodPathAnno.value());
+                                .path(classPathAnno.value() + "/" + methodPathAnno.value());
             } else if (classPathAnno != null) {
-                template = (ResteasyUriBuilder) new ResteasyUriBuilderImpl().uri(classPathAnno.value());
+                template = (ResteasyUriBuilder) new ResteasyUriBuilderImpl().path(classPathAnno.value());
             } else {
                 template = null;
             }

--- a/rest-client/src/test/java/org/jboss/resteasy/microprofile/client/RestClientWithEmptyPath.java
+++ b/rest-client/src/test/java/org/jboss/resteasy/microprofile/client/RestClientWithEmptyPath.java
@@ -1,0 +1,12 @@
+package org.jboss.resteasy.microprofile.client;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+
+@Path("")
+public interface RestClientWithEmptyPath {
+    @Path("/{aPathParameter}")
+    @GET
+    String get(@PathParam("aPathParameter") String aPathParameter);
+}

--- a/rest-client/src/test/java/org/jboss/resteasy/microprofile/client/RestClientWithEmptyPathTest.java
+++ b/rest-client/src/test/java/org/jboss/resteasy/microprofile/client/RestClientWithEmptyPathTest.java
@@ -1,0 +1,15 @@
+package org.jboss.resteasy.microprofile.client;
+
+import org.eclipse.microprofile.rest.client.RestClientBuilder;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class RestClientWithEmptyPathTest {
+    @Test
+    public void testBuildRestClient() {
+        // the client get created without errors
+        Assertions.assertDoesNotThrow(() -> RestClientBuilder.newBuilder()
+                .baseUri("http://localhost")
+                .build(RestClientWithEmptyPath.class));
+    }
+}


### PR DESCRIPTION
…ue on the rest client interface is empty

When @Path annotation on the rest client interface has an empty value (i.e. ""), and the @Path annotation on the method is in the form "/{aPathParameter}", the method RestClientBuilderImpl.verifyInterface throws an error stating

"RestClientDefinition Parameters and variables don't match on interface"

This is caused by the method ResteasyUriBuilderImpl.uri interpreting the first parameter in the path as the host.

Using the method ResteasyUriBuilderImpl.path fixes the issue.

Fixes #530