### PR TITLE
[545] By default escape the [] when using array parameters in a query…

### DIFF
--- a/rest-client-base/src/main/java/org/jboss/resteasy/microprofile/client/impl/MpUriBuilder.java
+++ b/rest-client-base/src/main/java/org/jboss/resteasy/microprofile/client/impl/MpUriBuilder.java
@@ -23,17 +23,23 @@ import java.net.URI;
 
 import jakarta.ws.rs.core.UriBuilder;
 
+import org.eclipse.microprofile.config.Config;
+import org.eclipse.microprofile.config.ConfigProvider;
 import org.eclipse.microprofile.rest.client.ext.QueryParamStyle;
 import org.jboss.resteasy.resteasy_jaxrs.i18n.Messages;
 import org.jboss.resteasy.specimpl.ResteasyUriBuilderImpl;
 import org.jboss.resteasy.util.Encode;
 
 public class MpUriBuilder extends ResteasyUriBuilderImpl {
+    private static final String ENCODE_ARRAY_BRACKETS = "dev.resteasy.mp.rest.client.encodeArrayBrackets";
 
+    private final boolean encodeArrayBrackets;
     private QueryParamStyle queryParamStyle = null;
 
     public MpUriBuilder() {
         super();
+        final Config config = ConfigProvider.getConfig();
+        encodeArrayBrackets = config.getOptionalValue(ENCODE_ARRAY_BRACKETS, Boolean.class).orElse(false);
     }
 
     /*
@@ -44,6 +50,8 @@ public class MpUriBuilder extends ResteasyUriBuilderImpl {
             final String userInfo, final String path, final String query,
             final String fragment, final String ssp, final String authority) {
         super(host, scheme, port, userInfo, path, query, fragment, ssp, authority);
+        final Config config = ConfigProvider.getConfig();
+        encodeArrayBrackets = config.getOptionalValue(ENCODE_ARRAY_BRACKETS, Boolean.class).orElse(false);
     }
 
     public void setQueryParamStyle(QueryParamStyle queryParamStyle) {
@@ -156,9 +164,13 @@ public class MpUriBuilder extends ResteasyUriBuilderImpl {
             }
             sb.append(prefix);
             prefix = "&";
-            sb.append(Encode.encodeQueryParamAsIs(name))
-                    .append("[]=")
-                    .append(Encode.encodeQueryParamAsIs(value.toString()));
+            sb.append(Encode.encodeQueryParamAsIs(name));
+            if (encodeArrayBrackets) {
+                sb.append("%5b%5d=");
+            } else {
+                sb.append("[]=");
+            }
+            sb.append(Encode.encodeQueryParamAsIs(value.toString()));
         }
 
         replaceQueryNoEncoding(sb.toString());

--- a/testsuite/integration-tests/pom.xml
+++ b/testsuite/integration-tests/pom.xml
@@ -210,6 +210,12 @@
                     <systemPropertyVariables>
                         <jboss.home>${jboss.home}</jboss.home>
                         <java.io.tmpdir>${project.build.directory}</java.io.tmpdir>
+                        <!-- This is a workaround for UNDERTOW-2771. As of WildFly 40, the [] brackets in a query parameter
+                             throw an exception as being invalid. In #545 we introduce this new property which will encode
+                             the brackets. In the future this can be removed once WildFly aligns with a newer version of
+                             Undertow. However, that is not required.
+                         -->
+                        <dev.resteasy.mp.rest.client.encodeArrayBrackets>true</dev.resteasy.mp.rest.client.encodeArrayBrackets>
                     </systemPropertyVariables>
                 </configuration>
                 <executions>


### PR DESCRIPTION
… string to be RFC3986 compliant. Introduce a new property to allow this compliance to be disable, which needs to be done for the TCK.

resolves #545